### PR TITLE
🚀 [Feature] Date-based prerelease suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The action have the following parameters:
 | --- | --- | --- | --- |
 | `AutoPatching` | Control wether to automatically handle patches. If disabled, the action will only create a patch release if the pull request has a 'patch' label. | `true` | false |
 | `IncrementalPrerelease` | Control wether to automatically increment the prerelease number. If disabled, the action will ensure only one prerelease exists for a given branch. | `true` | false |
+| `DataPrereleaseFormat` | The format to use for the prerelease number using [.NET DateTime format strings](https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings). | `''` | false |
 | `VersionPrefix` | The prefix to use for the version number. | `v` | false |
 
 ### Example

--- a/action.yml
+++ b/action.yml
@@ -33,4 +33,4 @@ runs:
         IncrementalPrerelease: ${{ inputs.IncrementalPrerelease }}
         VersionPrefix: ${{ inputs.VersionPrefix }}
         DatePrereleaseFormat: ${{ inputs.DatePrereleaseFormat }}
-      run: ./scripts/main.ps1
+      run: scripts/main.ps1

--- a/action.yml
+++ b/action.yml
@@ -33,4 +33,4 @@ runs:
         IncrementalPrerelease: ${{ inputs.IncrementalPrerelease }}
         VersionPrefix: ${{ inputs.VersionPrefix }}
         DatePrereleaseFormat: ${{ inputs.DatePrereleaseFormat }}
-      run: . ./scripts/main.ps1
+      run: . "$env:GITHUB_ACTION_PATH\scripts\main.ps1"

--- a/action.yml
+++ b/action.yml
@@ -33,4 +33,4 @@ runs:
         IncrementalPrerelease: ${{ inputs.IncrementalPrerelease }}
         VersionPrefix: ${{ inputs.VersionPrefix }}
         DatePrereleaseFormat: ${{ inputs.DatePrereleaseFormat }}
-      run: scripts/main.ps1
+      run: . ./scripts/main.ps1

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: Control wether to automatically increment the prerelease number. If disabled, the action will ensure only one prerelease exists for a given branch.
     required: false
     default: 'true'
+  DatePrereleaseFormat:
+    description: If specified, uses a date based prerelease scheme. The format should be a valid .NET format string like 'yyyyMMddHHmm'.
+    required: false
+    default: ''
   VersionPrefix:
     description: The prefix to use for the version number.
     required: false
@@ -28,4 +32,5 @@ runs:
         AutoPatching: ${{ inputs.AutoPatching }}
         IncrementalPrerelease: ${{ inputs.IncrementalPrerelease }}
         VersionPrefix: ${{ inputs.VersionPrefix }}
+        DatePrereleaseFormat: ${{ inputs.DatePrereleaseFormat }}
       run: ./scripts/main.ps1

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -17,10 +17,13 @@ Write-Output '::endgroup::'
 
 $autoPatching = $env:AutoPatching -eq 'true'
 $incrementalPrerelease = $env:IncrementalPrerelease -eq 'true'
+$datePrereleaseFormat = $env:DatePrereleaseFormat
 $versionPrefix = $env:VersionPrefix
+
 Write-Output '-------------------------------------------------'
 Write-Output "Auto patching enabled:          [$autoPatching]"
-Write-Output "Incremental prerelease enabled: [$autoPatching]"
+Write-Output "Incremental prerelease enabled: [$incrementalPrerelease]"
+Write-Output "Date-based prerelease format:   [$datePrerelease]"
 Write-Output "Version prefix:                 [$versionPrefix]"
 Write-Output '-------------------------------------------------'
 
@@ -138,6 +141,12 @@ if ($preRelease) {
     Write-Output "Adding a prerelease tag to the version using the branch name [$preReleaseName]."
     $newVersion = "$newVersion-$preReleaseName"
     Write-Output "Partly new version: [$newVersion]"
+
+    if ($env:DatePrereleaseFormat | IsNotNullOrEmpty) {
+        Write-Output "Using date-based prerelease: [$datePrereleaseFormat]."
+        $newVersion = $newVersion + '.' + (Get-Date -Format 'yyyyMMddHHmm')
+        Write-Output "Partly new version: [$newVersion]"
+    }
 
     if ($incrementalPrerelease) {
         $prereleases = $releases | Where-Object { $_.tagName -like "$newVersion*" } | Sort-Object -Descending -Property tagName

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -23,7 +23,7 @@ $versionPrefix = $env:VersionPrefix
 Write-Output '-------------------------------------------------'
 Write-Output "Auto patching enabled:          [$autoPatching]"
 Write-Output "Incremental prerelease enabled: [$incrementalPrerelease]"
-Write-Output "Date-based prerelease format:   [$datePrerelease]"
+Write-Output "Date-based prerelease format:   [$datePrereleaseFormat]"
 Write-Output "Version prefix:                 [$versionPrefix]"
 Write-Output '-------------------------------------------------'
 
@@ -144,7 +144,7 @@ if ($preRelease) {
 
     if ($env:DatePrereleaseFormat | IsNotNullOrEmpty) {
         Write-Output "Using date-based prerelease: [$datePrereleaseFormat]."
-        $newVersion = $newVersion + '.' + (Get-Date -Format 'yyyyMMddHHmm')
+        $newVersion = $newVersion + '.' + (Get-Date -Format $datePrereleaseFormat)
         Write-Output "Partly new version: [$newVersion]"
     }
 


### PR DESCRIPTION
- Resolves #8 but instead of having to choose incremental or date-based, you can use both.

Other:
- Fixes an issue where the action main script did not run. Path was incorrect when running in a remote repo.
- Fixes a log issue where the setting of the incremental feature enablement was showing incorrect value.