### PR TITLE
🚀[Feature] Specify configuration using a config file

### DIFF
--- a/.github/workflows/Auto-Release.yml
+++ b/.github/workflows/Auto-Release.yml
@@ -1,6 +1,6 @@
 name: Auto-Release
 
-run-name: Auto-Release - [${{ github.event.pull_request.title }} \#${{ github.event.pull_request.number }}] by @${{ github.actor }}
+run-name: "Auto-Release - [${{ github.event.pull_request.title }} #${{ github.event.pull_request.number }}] by @${{ github.actor }}"
 
 on:
   pull_request_target:

--- a/.github/workflows/Auto-Release.yml
+++ b/.github/workflows/Auto-Release.yml
@@ -1,5 +1,7 @@
 name: Auto-Release
 
+run-name: Auto-Release - [${{ github.event.pull_request.title }} \#${{ github.event.pull_request.number }}] by @${{ github.actor }}
+
 on:
   pull_request_target:
     branches:

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -1,5 +1,7 @@
 name: Linter
 
+run-name: "Linter - [${{ github.event.pull_request.title }} #${{ github.event.pull_request.number }}] by @${{ github.actor }}"
+
 on:
   pull_request_target:
     branches:

--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ The action have the following parameters:
 | --- | --- | --- | --- |
 | `AutoCleanup`| Control wether to automatically cleanup prereleases. If disabled, the action will not remove any prereleases. | `true` | false |
 | `AutoPatching` | Control wether to automatically handle patches. If disabled, the action will only create a patch release if the pull request has a 'patch' label. | `true` | false |
+| `ConfigurationFile` | The path to the configuration file. Settings in the configuration file take precedence over the action inputs. | `.github\auto-release.yml` | false |
 | `CreateMajorTag` | Control wether to create a tag for major releases. | `true` | false |
 | `CreateMinorTag` | Control wether to create a tag for minor releases. | `true` | false |
 | `DatePrereleaseFormat` | The format to use for the prerelease number using [.NET DateTime format strings](https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings). | `''` | false |
-| `IncrementalPrerelease` | Control wether to automatically increment the prerelease number. If disabled, the action will ensure only one prerelease exists for a given branch. | `true` | false |
+| `IncrementalPrerelease` | Control wether to automatically increment the prerelease number. If disabled, the action will ensure only one prerelease exists for a given branch. | `false` | false |
 | `VersionPrefix` | The prefix to use for the version number. | `v` | false |
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The action have the following parameters:
 | `CreateMajorTag` | Control wether to create a tag for major releases. | `true` | false |
 | `CreateMinorTag` | Control wether to create a tag for minor releases. | `true` | false |
 | `DatePrereleaseFormat` | The format to use for the prerelease number using [.NET DateTime format strings](https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings). | `''` | false |
-| `IncrementalPrerelease` | Control wether to automatically increment the prerelease number. If disabled, the action will ensure only one prerelease exists for a given branch. | `false` | false |
+| `IncrementalPrerelease` | Control wether to automatically increment the prerelease number. If disabled, the action will ensure only one prerelease exists for a given branch. | `true` | false |
 | `VersionPrefix` | The prefix to use for the version number. | `v` | false |
 
 ### Example

--- a/action.yml
+++ b/action.yml
@@ -6,10 +6,38 @@ branding:
   color: blue
 
 inputs:
+  AutoCleanup:
+    description: Control wether to automatically delete the prerelease tags after the stable release is created.
+    required: false
+    default: 'true'
+  AutoPatching:
+    description: Control wether to automatically handle patches. If disabled, the action will only create a patch release if the pull request has a 'patch' label.
+    required: false
+    default: 'true'
   ConfigurationFile:
     description: The path to the configuration file.
     required: false
-    default: '.github\auto-release.yml'
+    default: .github\auto-release.yml
+  CreateMajorTag:
+    description: Control wether to create a major tag when a pull request is merged into the main branch.
+    required: false
+    default: 'true'
+  CreateMinorTag:
+    description: Control wether to create a minor tag when a pull request is merged into the main branch.
+    required: false
+    default: 'true'
+  DatePrereleaseFormat:
+    description: If specified, uses a date based prerelease scheme. The format should be a valid .NET format string like 'yyyyMMddHHmm'.
+    required: false
+    default: ''
+  IncrementalPrerelease:
+    description: Control wether to automatically increment the prerelease number. If disabled, the action will ensure only one prerelease exists for a given branch.
+    required: false
+    default: 'true'
+  VersionPrefix:
+    description: The prefix to use for the version number.
+    required: false
+    default: 'v'
 
 runs:
   using: composite
@@ -17,5 +45,12 @@ runs:
     - name: Auto-Release
       shell: pwsh
       env:
+        AutoCleanup: ${{ inputs.AutoCleanup }}
+        AutoPatching: ${{ inputs.AutoPatching }}
         ConfigurationFile: ${{ inputs.ConfigurationFile }}
+        CreateMajorTag: ${{ inputs.CreateMajorTag }}
+        CreateMinorTag: ${{ inputs.CreateMinorTag }}
+        DatePrereleaseFormat: ${{ inputs.DatePrereleaseFormat }}
+        IncrementalPrerelease: ${{ inputs.IncrementalPrerelease }}
+        VersionPrefix: ${{ inputs.VersionPrefix }}
       run: . "$env:GITHUB_ACTION_PATH\scripts\main.ps1"

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
   IncrementalPrerelease:
     description: Control wether to automatically increment the prerelease number. If disabled, the action will ensure only one prerelease exists for a given branch.
     required: false
-    default: 'false'
+    default: 'true'
   VersionPrefix:
     description: The prefix to use for the version number.
     required: false

--- a/action.yml
+++ b/action.yml
@@ -6,34 +6,10 @@ branding:
   color: blue
 
 inputs:
-  AutoCleanup:
-    description: Control wether to automatically delete the prerelease tags after the stable release is created.
+  ConfigurationFile:
+    description: The path to the configuration file.
     required: false
-    default: 'true'
-  AutoPatching:
-    description: Control wether to automatically handle patches. If disabled, the action will only create a patch release if the pull request has a 'patch' label.
-    required: false
-    default: 'true'
-  CreateMajorTag:
-    description: Control wether to create a major tag when a pull request is merged into the main branch.
-    required: false
-    default: 'true'
-  CreateMinorTag:
-    description: Control wether to create a minor tag when a pull request is merged into the main branch.
-    required: false
-    default: 'true'
-  DatePrereleaseFormat:
-    description: If specified, uses a date based prerelease scheme. The format should be a valid .NET format string like 'yyyyMMddHHmm'.
-    required: false
-    default: ''
-  IncrementalPrerelease:
-    description: Control wether to automatically increment the prerelease number. If disabled, the action will ensure only one prerelease exists for a given branch.
-    required: false
-    default: 'true'
-  VersionPrefix:
-    description: The prefix to use for the version number.
-    required: false
-    default: 'v'
+    default: '.github\auto-release.yml'
 
 runs:
   using: composite
@@ -41,11 +17,5 @@ runs:
     - name: Auto-Release
       shell: pwsh
       env:
-        AutoCleanup: ${{ inputs.AutoCleanup }}
-        AutoPatching: ${{ inputs.AutoPatching }}
-        CreateMajorTag: ${{ inputs.CreateMajorTag }}
-        CreateMinorTag: ${{ inputs.CreateMinorTag }}
-        DatePrereleaseFormat: ${{ inputs.DatePrereleaseFormat }}
-        IncrementalPrerelease: ${{ inputs.IncrementalPrerelease }}
-        VersionPrefix: ${{ inputs.VersionPrefix }}
+        ConfigurationFile: ${{ inputs.ConfigurationFile }}
       run: . "$env:GITHUB_ACTION_PATH\scripts\main.ps1"

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: false
     default: 'true'
   ConfigurationFile:
-    description: The path to the configuration file.
+    description: The path to the configuration file. Settings in the configuration file take precedence over the action inputs.
     required: false
     default: .github\auto-release.yml
   CreateMajorTag:
@@ -33,7 +33,7 @@ inputs:
   IncrementalPrerelease:
     description: Control wether to automatically increment the prerelease number. If disabled, the action will ensure only one prerelease exists for a given branch.
     required: false
-    default: 'true'
+    default: 'false'
   VersionPrefix:
     description: The prefix to use for the version number.
     required: false

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -28,12 +28,14 @@ Write-Output '::group::Environment variables'
 Get-ChildItem -Path Env: | Select-Object Name, Value | Sort-Object Name | Format-Table -AutoSize
 Write-Output '::endgroup::'
 
-Write-Output "::group::Read configuration [$env:ConfigurationFile]"
+Write-Output "::group::Set configuration"
 if (-not (Test-Path -Path $env:ConfigurationFile -PathType Leaf)) {
     Write-Error "Configuration file not found at [$env:ConfigurationFile]"
     exit 1
+} else {
+    Write-Output "Reading from configuration file [$env:ConfigurationFile]"
+    $configuration = ConvertFrom-Yaml -Yaml (Get-Content $env:ConfigurationFile -Raw)
 }
-$configuration = ConvertFrom-Yaml -Yaml (Get-Content $env:ConfigurationFile -Raw)
 
 $autoCleanup = ($configuration.AutoCleanup | IsNotNullOrEmpty) ? $configuration.AutoCleanup -eq 'true' : $env:AutoCleanup -eq 'true'
 $autoPatching = ($configuration.AutoPatching | IsNotNullOrEmpty) ? $configuration.AutoPatching -eq 'true' : $env:AutoPatching -eq 'true'

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -183,7 +183,7 @@ if ($createPrerelease -or $createRelease) {
                 $_ | Add-Member -MemberType NoteProperty -Name 'number' -Value ($_.tagName -Split '.')[-1] -PassThru
             } | Sort-Object -Property number -Descending
             $prereleases | Format-Table
-            
+
             if ($prereleases.count -gt 0) {
                 $latestPrereleaseVersion = ($prereleases[0].tagName | ConvertTo-SemVer) | Select-Object -ExpandProperty Prerelease
                 Write-Output "Latest prerelease:              [$latestPrereleaseVersion]"

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -179,10 +179,8 @@ if ($createPrerelease -or $createRelease) {
         }
 
         if ($incrementalPrerelease) {
-            $prereleases = $releases | Where-Object { $_.tagName -like "$newVersion*" } | ForEach-Object {
-                $_ | Add-Member -MemberType NoteProperty -Name 'number' -Value [int](($_.tagName -Split '\.')[-1]) -PassThru -Force
-            } | Sort-Object -Property number -Descending
-            $prereleases | Select-Object -Property number, name, publishedAt, isPrerelease, isLatest | Format-Table
+            $prereleases = $releases | Where-Object { $_.tagName -like "$newVersion*" }
+            $prereleases | Select-Object -Property @{n = 'number'; e = { [int](($_.tagName -Split '\.')[-1]) } }, name, publishedAt, isPrerelease, isLatest | Format-Table
 
             if ($prereleases.count -gt 0) {
                 $latestPrereleaseVersion = ($prereleases[0].tagName | ConvertTo-SemVer) | Select-Object -ExpandProperty Prerelease

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -72,6 +72,7 @@ if (-not $isPullRequest) {
     'A release should not be created in this context. Exiting.'
     return
 }
+
 Write-Output '-------------------------------------------------'
 Write-Output "Is a pull request event:        [$isPullRequest]"
 Write-Output "Action type:                    [$($githubEvent.action)]"
@@ -96,8 +97,8 @@ $majorTags = @('major', 'breaking')
 $minorTags = @('minor', 'feature', 'improvement')
 $patchTags = @('patch', 'fix', 'bug')
 
-$createRelease = $pull_request.base.ref -eq 'main' -and $pull_request.merged -eq 'True'
-$closedPullRequest = $pull_request.state -eq 'closed' -and $pull_request.merged -eq 'False'
+$createRelease = $pull_request.base.ref -eq 'main' -and ($pull_request.merged).ToString() -eq 'True'
+$closedPullRequest = $pull_request.state -eq 'closed' -and ($pull_request.merged).ToString() -eq 'False'
 $preRelease = $labels -Contains 'prerelease'
 $createPrerelease = $preRelease -and -not $createRelease
 

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -179,7 +179,9 @@ if ($createPrerelease -or $createRelease) {
         }
 
         if ($incrementalPrerelease) {
-            $prereleases = $releases | Where-Object { $_.tagName -like "$newVersion*" } | Sort-Object -Descending -Property publishedAt
+            $prereleases = $releases | Where-Object { $_.tagName -like "$newVersion*" } | ForEach-Object {
+                $_ | Add-Member -MemberType NoteProperty -Name 'number' -Value ($_.tagName -Split '.')[-1] -PassThru
+            } | Sort-Object -Property number -Descending
             Write-Output "Prereleases:                    [$($prereleases.count)]"
             if ($prereleases.count -gt 0) {
                 $latestPrereleaseVersion = ($prereleases[0].tagName | ConvertTo-SemVer) | Select-Object -ExpandProperty Prerelease

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -252,7 +252,7 @@ if ($createPrerelease -or $createRelease) {
     Write-Output 'Skipping release creation.'
 }
 
-Write-Output '::group::Lit prereleases using the same name'
+Write-Output '::group::List prereleases using the same name'
 $prereleasesToCleanup = $releases | Where-Object { $_.tagName -like "*$preReleaseName*" }
 $prereleasesToCleanup | Format-List
 Write-Output '::endgroup::'

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -100,7 +100,7 @@ $patchTags = @('patch', 'fix', 'bug')
 $createRelease = $pull_request.base.ref -eq 'main' -and ($pull_request.merged).ToString() -eq 'True'
 $closedPullRequest = $pull_request.state -eq 'closed' -and ($pull_request.merged).ToString() -eq 'False'
 $preRelease = $labels -Contains 'prerelease'
-$createPrerelease = $preRelease -and -not $createRelease
+$createPrerelease = $preRelease -and -not $createRelease -and -not $closedPullRequest
 
 $majorRelease = (Compare-Object -ReferenceObject $labels -DifferenceObject $majorTags -IncludeEqual -ExcludeDifferent).Count -gt 0
 $minorRelease = (Compare-Object -ReferenceObject $labels -DifferenceObject $minorTags -IncludeEqual -ExcludeDifferent).Count -gt 0 -and -not $majorRelease

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -14,22 +14,22 @@ Write-Output '::endgroup::'
 Write-Output '::group::Install - powershell-yaml'
 Install-PSResource -Name powershell-yaml -TrustRepository
 Write-Output '-------------------------------------------------'
-Get-PSResource -Name Utilities | Format-Table
+Get-PSResource -Name powershell-yaml | Format-Table
 Write-Output '-------------------------------------------------'
 Write-Output 'Get commands'
-Get-Command -Module Utilities | Format-Table
+Get-Command -Module powershell-yaml | Format-Table
 Write-Output '-------------------------------------------------'
 Write-Output 'Get aliases'
-Get-Alias | Where-Object Source -EQ 'Utilities' | Format-Table
+Get-Alias | Where-Object Source -EQ 'powershell-yaml' | Format-Table
 Write-Output '-------------------------------------------------'
 Write-Output '::endgroup::'
 
-Write-Output "::group::Read configuration [$env:ConfigurationPath]"
-if (-not (Test-Path -Path $env:ConfigurationPath -PathType Leaf)) {
-    Write-Error "Configuration file not found at [$env:ConfigurationPath]"
+Write-Output "::group::Read configuration [$env:ConfigurationFile]"
+if (-not (Test-Path -Path $env:ConfigurationFile -PathType Leaf)) {
+    Write-Error "Configuration file not found at [$env:ConfigurationFile]"
     exit 1
 }
-$configuration = ConvertFrom-Yaml -Yaml (Get-Content $env:ConfigurationPath -Raw)
+$configuration = ConvertFrom-Yaml -Yaml (Get-Content $env:ConfigurationFile -Raw)
 Write-Output '::endgroup::'
 
 $autoCleanup = $configuration.AutoCleanup -eq 'true'

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -31,12 +31,12 @@ if (-not (Test-Path -Path $env:ConfigurationFile -PathType Leaf)) {
 }
 $configuration = ConvertFrom-Yaml -Yaml (Get-Content $env:ConfigurationFile -Raw)
 
-$autoCleanup = $configuration.AutoCleanup -eq 'true'
-$autoPatching = $configuration.AutoPatching -eq 'true'
-$createMajorTag = $configuration.CreateMajorTag -eq 'true'
-$createMinorTag = $configuration.CreateMinorTag -eq 'true'
+$autoCleanup = ($configuration.AutoCleanup | IsNotNullOrEmpty) ? $configuration.AutoCleanup -eq 'true' : $true
+$autoPatching = ($configuration.AutoPatching | IsNotNullOrEmpty) ? $configuration.AutoPatching -eq 'true' : $true
+$createMajorTag = ($configuration.CreateMajorTag | IsNotNullOrEmpty) ? $configuration.CreateMajorTag -eq 'true' : $true
+$createMinorTag = ($configuration.CreateMinorTag | IsNotNullOrEmpty) ? $configuration.CreateMinorTag -eq 'true' : $true
 $datePrereleaseFormat = $configuration.DatePrereleaseFormat
-$incrementalPrerelease = $configuration.IncrementalPrerelease -eq 'true'
+$incrementalPrerelease = ($configuration.IncrementalPrerelease | IsNotNullOrEmpty) ? $configuration.IncrementalPrerelease -eq 'true' : $true
 $versionPrefix = $configuration.VersionPrefix
 
 Write-Output '-------------------------------------------------'

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -259,7 +259,7 @@ if ($createPrerelease -or $createRelease) {
     Write-Output 'Skipping release creation.'
     Write-Output"::notice::Skipping release creation."
 }
-
+'### Hello world! :rocket:' | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
 if (($closedPullRequest -or $createRelease) -and $autoCleanup) {
     Write-Output "::group::Cleanup prereleases for [$preReleaseName]"
     $prereleasesToCleanup = $releases | Where-Object { $_.tagName -like "*$preReleaseName*" }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -180,7 +180,7 @@ if ($createPrerelease -or $createRelease) {
 
         if ($incrementalPrerelease) {
             $prereleases = $releases | Where-Object { $_.tagName -like "$newVersion*" } | ForEach-Object {
-                $_ | Add-Member -MemberType NoteProperty -Name 'number' -Value [int](($_.tagName -Split '\.')[-1]) -TypeName int -PassThru -Force
+                $_ | Add-Member -MemberType  -Name 'number' -Value [int](($_.tagName -Split '\.')[-1]) -TypeName int -PassThru -Force
             } | Sort-Object -Property number -Descending
             $prereleases | Select-Object -Property number, name, publishedAt, isPrerelease, isLatest | Format-Table
 

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -182,7 +182,7 @@ if ($createPrerelease -or $createRelease) {
             $prereleases = $releases | Where-Object { $_.tagName -like "$newVersion*" } | ForEach-Object {
                 $_ | Add-Member -MemberType NoteProperty -Name 'number' -Value ($_.tagName -Split '.')[-1] -PassThru
             } | Sort-Object -Property number -Descending
-            $prereleases | Format-Table
+            $prereleases | Select-Object -Property number, name, publishedAt, isPrerelease, isLatest | Format-Table
 
             if ($prereleases.count -gt 0) {
                 $latestPrereleaseVersion = ($prereleases[0].tagName | ConvertTo-SemVer) | Select-Object -ExpandProperty Prerelease
@@ -257,7 +257,7 @@ Write-Output "::notice::Release created: [$newVersion]"
 
 Write-Output '::group::List prereleases using the same name'
 $prereleasesToCleanup = $releases | Where-Object { $_.tagName -like "*$preReleaseName*" }
-$prereleasesToCleanup | Select-Object -Property name, publishedAt, isDraft, isPrerelease, isLatest | Format-Table
+$prereleasesToCleanup | Select-Object -Property name, publishedAt, isPrerelease, isLatest | Format-Table
 Write-Output '::endgroup::'
 
 if (($closedPullRequest -or $createRelease) -and $autoCleanup) {

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -252,9 +252,13 @@ if ($createPrerelease -or $createRelease) {
     Write-Output 'Skipping release creation.'
 }
 
+Write-Output '::group::Lit prereleases using the same name'
+$prereleasesToCleanup = $releases | Where-Object { $_.tagName -like "*$preReleaseName*" }
+$prereleasesToCleanup | Format-List
+Write-Output '::endgroup::'
+
 if (($closedPullRequest -or $createRelease) -and $autoCleanup) {
     Write-Output "::group::Cleanup prereleases for [$preReleaseName]"
-    $prereleasesToCleanup = $releases | Where-Object { $_.tagName -like "*$preReleaseName*" }
     foreach ($rel in $prereleasesToCleanup) {
         $relTagName = $rel.tagName
         Write-Output "Deleting prerelease:            [$relTagName]."

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -180,7 +180,7 @@ if ($createPrerelease -or $createRelease) {
 
         if ($incrementalPrerelease) {
             $prereleases = $releases | Where-Object { $_.tagName -like "$newVersion*" } | ForEach-Object {
-                $_ | Add-Member -MemberType NoteProperty -Name 'number' -Value ($_.tagName -Split '\.')[-1] -PassThru -Force
+                $_ | Add-Member -MemberType NoteProperty -Name 'number' -Value [int]($_.tagName -Split '\.')[-1] -TypeName int -PassThru -Force
             } | Sort-Object -Property number -Descending
             $prereleases | Select-Object -Property number, name, publishedAt, isPrerelease, isLatest | Format-Table
 

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -30,7 +30,6 @@ if (-not (Test-Path -Path $env:ConfigurationFile -PathType Leaf)) {
     exit 1
 }
 $configuration = ConvertFrom-Yaml -Yaml (Get-Content $env:ConfigurationFile -Raw)
-Write-Output '::endgroup::'
 
 $autoCleanup = $configuration.AutoCleanup -eq 'true'
 $autoPatching = $configuration.AutoPatching -eq 'true'
@@ -49,16 +48,17 @@ Write-Output "Date-based prerelease format:   [$datePrereleaseFormat]"
 Write-Output "Incremental prerelease enabled: [$incrementalPrerelease]"
 Write-Output "Version prefix:                 [$versionPrefix]"
 Write-Output '-------------------------------------------------'
+Write-Output '::endgroup::'
 
-$githubEventJson = Get-Content $env:GITHUB_EVENT_PATH
-$githubEvent = $githubEventJson | ConvertFrom-Json
-$pull_request = $githubEvent.pull_request
 
 Write-Output '::group::Event information - JSON'
+$githubEventJson = Get-Content $env:GITHUB_EVENT_PATH
 $githubEventJson | Format-List
 Write-Output '::endgroup::'
 
 Write-Output '::group::Event information - Object'
+$githubEvent = $githubEventJson | ConvertFrom-Json
+$pull_request = $githubEvent.pull_request
 $githubEvent | Format-List
 Write-Output '::endgroup::'
 

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -205,6 +205,7 @@ if ($createPrerelease -or $createRelease) {
             gh release delete $newVersion --cleanup-tag --yes
             if ($LASTEXITCODE -ne 0) {
                 Write-Error "Failed to delete the release [$newVersion]."
+                Write-Output "::error::Failed to delete the release [$newVersion]."
                 exit $LASTEXITCODE
             }
         }
@@ -212,6 +213,7 @@ if ($createPrerelease -or $createRelease) {
         gh release create $newVersion --title $newVersion --generate-notes --prerelease
         if ($LASTEXITCODE -ne 0) {
             Write-Error "Failed to create the release [$newVersion]."
+            Write-Output "::error::Failed to create the release [$newVersion]."
             exit $LASTEXITCODE
         }
         return
@@ -220,14 +222,17 @@ if ($createPrerelease -or $createRelease) {
     gh release create $newVersion --title $newVersion --generate-notes
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Failed to create the release [$newVersion]."
+        Write-Output "::error::Failed to create the release [$newVersion]."
         exit $LASTEXITCODE
     }
+    Write-Output "::notice::Release created - [$newVersion]"
 
     if ($createMajorTag) {
         $majorTag = ('{0}{1}' -f $versionPrefix, $major)
         git tag -f $majorTag 'main'
         if ($LASTEXITCODE -ne 0) {
             Write-Error "Failed to create major tag [$majorTag]."
+            Write-Output "::error::Failed to create major tag [$majorTag]."
             exit $LASTEXITCODE
         }
     }
@@ -237,6 +242,7 @@ if ($createPrerelease -or $createRelease) {
         git tag -f $minorTag 'main'
         if ($LASTEXITCODE -ne 0) {
             Write-Error "Failed to create minor tag [$minorTag]."
+            Write-Output "::error::Failed to create minor tag [$minorTag]."
             exit $LASTEXITCODE
         }
     }
@@ -244,12 +250,14 @@ if ($createPrerelease -or $createRelease) {
     git push origin --tags --force
     if ($LASTEXITCODE -ne 0) {
         Write-Error 'Failed to push tags.'
+        Write-Output "::error::Failed to push tags."
         exit $LASTEXITCODE
     }
     Write-Output '::endgroup::'
 
 } else {
     Write-Output 'Skipping release creation.'
+    Write-Output"::notice::Skipping release creation."
 }
 
 if (($closedPullRequest -or $createRelease) -and $autoCleanup) {
@@ -261,8 +269,10 @@ if (($closedPullRequest -or $createRelease) -and $autoCleanup) {
         gh release delete $rel.tagName --cleanup-tag --yes
         if ($LASTEXITCODE -ne 0) {
             Write-Error "Failed to delete release [$relTagName]."
+            Write-Output "::error::Failed to delete release [$relTagName]."
             exit $LASTEXITCODE
         }
+        Write-Output"::notice::Prerelease deleted - [$relTagName]"
     }
     Write-Output '::endgroup::'
 }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -180,7 +180,7 @@ if ($createPrerelease -or $createRelease) {
 
         if ($incrementalPrerelease) {
             $prereleases = $releases | Where-Object { $_.tagName -like "$newVersion*" } | ForEach-Object {
-                $_ | Add-Member -MemberType NoteProperty -Name 'number' -Value (($_.tagName -Split '\.')[-1]).ToInt16() -TypeName Int -PassThru -Force
+                $_ | Add-Member -MemberType NoteProperty -Name 'number' -Value [int](($_.tagName -Split '\.')[-1]) -TypeName Int -PassThru -Force
             } | Sort-Object -Property number -Descending
             $prereleases | Select-Object -Property number, name, publishedAt, isPrerelease, isLatest | Format-Table
 

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -251,6 +251,8 @@ if ($createPrerelease -or $createRelease) {
 }
 
 Write-Output "::notice::Release created: [$newVersion]"
+Write-Output "::warning::Release created: [$newVersion]"
+Write-Output "::error::Release created: [$newVersion]"
 
 Write-Output '::group::List prereleases using the same name'
 $prereleasesToCleanup = $releases | Where-Object { $_.tagName -like "*$preReleaseName*" }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -250,6 +250,8 @@ if ($createPrerelease -or $createRelease) {
     Write-Output 'Skipping release creation.'
 }
 
+Write-Output "::notice::Release created: [$newVersion]"
+
 Write-Output '::group::List prereleases using the same name'
 $prereleasesToCleanup = $releases | Where-Object { $_.tagName -like "*$preReleaseName*" }
 $prereleasesToCleanup | Select-Object -Property name, publishedAt,isDraft,isPrerelease,isLatest | Format-Table

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -252,7 +252,7 @@ if ($createPrerelease -or $createRelease) {
 
 Write-Output '::group::List prereleases using the same name'
 $prereleasesToCleanup = $releases | Where-Object { $_.tagName -like "*$preReleaseName*" }
-$prereleasesToCleanup | Format-List
+$prereleasesToCleanup | Select-Object -Property name, publishedAt,isDraft,isPrerelease,isLatest | Format-Table
 Write-Output '::endgroup::'
 
 if (($closedPullRequest -or $createRelease) -and $autoCleanup) {

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -30,8 +30,7 @@ Write-Output '::endgroup::'
 
 Write-Output "::group::Set configuration"
 if (-not (Test-Path -Path $env:ConfigurationFile -PathType Leaf)) {
-    Write-Error "Configuration file not found at [$env:ConfigurationFile]"
-    exit 1
+    Write-Output "Configuration file not found at [$env:ConfigurationFile]"
 } else {
     Write-Output "Reading from configuration file [$env:ConfigurationFile]"
     $configuration = ConvertFrom-Yaml -Yaml (Get-Content $env:ConfigurationFile -Raw)

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -183,7 +183,7 @@ if ($createPrerelease -or $createRelease) {
                 $_ | Add-Member -MemberType NoteProperty -Name 'number' -Value ($_.tagName -Split '.')[-1] -PassThru
             } | Sort-Object -Property number -Descending
             $prereleases | Format-Table
-            Write-Output "Prereleases:                    [$($prereleases.count)]"
+            
             if ($prereleases.count -gt 0) {
                 $latestPrereleaseVersion = ($prereleases[0].tagName | ConvertTo-SemVer) | Select-Object -ExpandProperty Prerelease
                 Write-Output "Latest prerelease:              [$latestPrereleaseVersion]"

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -122,7 +122,7 @@ if ($createPrerelease -or $createRelease) {
         Write-Error 'Failed to list all releases for the repo.'
         exit $LASTEXITCODE
     }
-    $releases | Format-List
+    $releases | Select-Object -Property name, isDraft, isPrerelease, isLatest, publishedAt, createdAt | Format-Table
     Write-Output '::endgroup::'
 
     Write-Output '::group::Get latest version'
@@ -254,7 +254,7 @@ Write-Output "::notice::Release created: [$newVersion]"
 
 Write-Output '::group::List prereleases using the same name'
 $prereleasesToCleanup = $releases | Where-Object { $_.tagName -like "*$preReleaseName*" }
-$prereleasesToCleanup | Select-Object -Property name, publishedAt,isDraft,isPrerelease,isLatest | Format-Table
+$prereleasesToCleanup | Select-Object -Property name, publishedAt, isDraft, isPrerelease, isLatest | Format-Table
 Write-Output '::endgroup::'
 
 if (($closedPullRequest -or $createRelease) -and $autoCleanup) {

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -179,7 +179,7 @@ if ($createPrerelease -or $createRelease) {
         }
 
         if ($incrementalPrerelease) {
-            $prereleases = $releases | Where-Object { $_.tagName -like "$newVersion*" } | Sort-Object -Descending -Property tagName
+            $prereleases = $releases | Where-Object { $_.tagName -like "$newVersion*" } | Sort-Object -Descending -Property publishedAt
             Write-Output "Prereleases:                    [$($prereleases.count)]"
             if ($prereleases.count -gt 0) {
                 $latestPrereleaseVersion = ($prereleases[0].tagName | ConvertTo-SemVer) | Select-Object -ExpandProperty Prerelease

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -180,7 +180,7 @@ if ($createPrerelease -or $createRelease) {
 
         if ($incrementalPrerelease) {
             $prereleases = $releases | Where-Object { $_.tagName -like "$newVersion*" } | ForEach-Object {
-                $_ | Add-Member -MemberType NoteProperty -Name 'number' -Value [int](($_.tagName -Split '\.')[-1]) -TypeName Int -PassThru -Force
+                $_ | Add-Member -MemberType NoteProperty -Name 'number' -Value [int](($_.tagName -Split '\.')[-1]) -PassThru -Force
             } | Sort-Object -Property number -Descending
             $prereleases | Select-Object -Property number, name, publishedAt, isPrerelease, isLatest | Format-Table
 

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -182,6 +182,7 @@ if ($createPrerelease -or $createRelease) {
             $prereleases = $releases | Where-Object { $_.tagName -like "$newVersion*" } | ForEach-Object {
                 $_ | Add-Member -MemberType NoteProperty -Name 'number' -Value ($_.tagName -Split '.')[-1] -PassThru
             } | Sort-Object -Property number -Descending
+            $prereleases | Format-Table
             Write-Output "Prereleases:                    [$($prereleases.count)]"
             if ($prereleases.count -gt 0) {
                 $latestPrereleaseVersion = ($prereleases[0].tagName | ConvertTo-SemVer) | Select-Object -ExpandProperty Prerelease

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -205,7 +205,6 @@ if ($createPrerelease -or $createRelease) {
             gh release delete $newVersion --cleanup-tag --yes
             if ($LASTEXITCODE -ne 0) {
                 Write-Error "Failed to delete the release [$newVersion]."
-                Write-Output "::error::Failed to delete the release [$newVersion]."
                 exit $LASTEXITCODE
             }
         }
@@ -213,7 +212,6 @@ if ($createPrerelease -or $createRelease) {
         gh release create $newVersion --title $newVersion --generate-notes --prerelease
         if ($LASTEXITCODE -ne 0) {
             Write-Error "Failed to create the release [$newVersion]."
-            Write-Output "::error::Failed to create the release [$newVersion]."
             exit $LASTEXITCODE
         }
         return
@@ -222,17 +220,14 @@ if ($createPrerelease -or $createRelease) {
     gh release create $newVersion --title $newVersion --generate-notes
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Failed to create the release [$newVersion]."
-        Write-Output "::error::Failed to create the release [$newVersion]."
         exit $LASTEXITCODE
     }
-    Write-Output "::notice::Release created - [$newVersion]"
 
     if ($createMajorTag) {
         $majorTag = ('{0}{1}' -f $versionPrefix, $major)
         git tag -f $majorTag 'main'
         if ($LASTEXITCODE -ne 0) {
             Write-Error "Failed to create major tag [$majorTag]."
-            Write-Output "::error::Failed to create major tag [$majorTag]."
             exit $LASTEXITCODE
         }
     }
@@ -242,7 +237,6 @@ if ($createPrerelease -or $createRelease) {
         git tag -f $minorTag 'main'
         if ($LASTEXITCODE -ne 0) {
             Write-Error "Failed to create minor tag [$minorTag]."
-            Write-Output "::error::Failed to create minor tag [$minorTag]."
             exit $LASTEXITCODE
         }
     }
@@ -250,16 +244,14 @@ if ($createPrerelease -or $createRelease) {
     git push origin --tags --force
     if ($LASTEXITCODE -ne 0) {
         Write-Error 'Failed to push tags.'
-        Write-Output "::error::Failed to push tags."
         exit $LASTEXITCODE
     }
     Write-Output '::endgroup::'
 
 } else {
     Write-Output 'Skipping release creation.'
-    Write-Output"::notice::Skipping release creation."
 }
-'### Hello world! :rocket:' | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+
 if (($closedPullRequest -or $createRelease) -and $autoCleanup) {
     Write-Output "::group::Cleanup prereleases for [$preReleaseName]"
     $prereleasesToCleanup = $releases | Where-Object { $_.tagName -like "*$preReleaseName*" }
@@ -269,10 +261,8 @@ if (($closedPullRequest -or $createRelease) -and $autoCleanup) {
         gh release delete $rel.tagName --cleanup-tag --yes
         if ($LASTEXITCODE -ne 0) {
             Write-Error "Failed to delete release [$relTagName]."
-            Write-Output "::error::Failed to delete release [$relTagName]."
             exit $LASTEXITCODE
         }
-        Write-Output"::notice::Prerelease deleted - [$relTagName]"
     }
     Write-Output '::endgroup::'
 }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -180,7 +180,7 @@ if ($createPrerelease -or $createRelease) {
 
         if ($incrementalPrerelease) {
             $prereleases = $releases | Where-Object { $_.tagName -like "$newVersion*" } | ForEach-Object {
-                $_ | Add-Member -MemberType NoteProperty -Name 'number' -Value [int](($_.tagName -Split '\.')[-1]) -TypeName int -PassThru -Force
+                $_ | Add-Member -MemberType NoteProperty -Name 'number' -Value (($_.tagName -Split '\.')[-1]).ToInt16() -TypeName Int -PassThru -Force
             } | Sort-Object -Property number -Descending
             $prereleases | Select-Object -Property number, name, publishedAt, isPrerelease, isLatest | Format-Table
 

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -24,6 +24,10 @@ Get-Alias | Where-Object Source -EQ 'powershell-yaml' | Format-Table
 Write-Output '-------------------------------------------------'
 Write-Output '::endgroup::'
 
+Write-Output '::group::Environment variables'
+Get-ChildItem -Path Env: | Select-Object Name, Value | Sort-Object Name | Format-Table -AutoSize
+Write-Output '::endgroup::'
+
 Write-Output "::group::Read configuration [$env:ConfigurationFile]"
 if (-not (Test-Path -Path $env:ConfigurationFile -PathType Leaf)) {
     Write-Error "Configuration file not found at [$env:ConfigurationFile]"
@@ -31,13 +35,13 @@ if (-not (Test-Path -Path $env:ConfigurationFile -PathType Leaf)) {
 }
 $configuration = ConvertFrom-Yaml -Yaml (Get-Content $env:ConfigurationFile -Raw)
 
-$autoCleanup = ($configuration.AutoCleanup | IsNotNullOrEmpty) ? $configuration.AutoCleanup -eq 'true' : $true
-$autoPatching = ($configuration.AutoPatching | IsNotNullOrEmpty) ? $configuration.AutoPatching -eq 'true' : $true
-$createMajorTag = ($configuration.CreateMajorTag | IsNotNullOrEmpty) ? $configuration.CreateMajorTag -eq 'true' : $true
-$createMinorTag = ($configuration.CreateMinorTag | IsNotNullOrEmpty) ? $configuration.CreateMinorTag -eq 'true' : $true
-$datePrereleaseFormat = $configuration.DatePrereleaseFormat
-$incrementalPrerelease = ($configuration.IncrementalPrerelease | IsNotNullOrEmpty) ? $configuration.IncrementalPrerelease -eq 'true' : $true
-$versionPrefix = $configuration.VersionPrefix
+$autoCleanup = ($configuration.AutoCleanup | IsNotNullOrEmpty) ? $configuration.AutoCleanup -eq 'true' : $env:AutoCleanup -eq 'true'
+$autoPatching = ($configuration.AutoPatching | IsNotNullOrEmpty) ? $configuration.AutoPatching -eq 'true' : $env:AutoPatching -eq 'true'
+$createMajorTag = ($configuration.CreateMajorTag | IsNotNullOrEmpty) ? $configuration.CreateMajorTag -eq 'true' : $env:CreateMajorTag -eq 'true'
+$createMinorTag = ($configuration.CreateMinorTag | IsNotNullOrEmpty) ? $configuration.CreateMinorTag -eq 'true' : $env:CreateMinorTag -eq 'true'
+$datePrereleaseFormat = ($configuration.DatePrereleaseFormat | IsNotNullOrEmpty) ? $configuration.DatePrereleaseFormat : $env:DatePrereleaseFormat
+$incrementalPrerelease = ($configuration.IncrementalPrerelease | IsNotNullOrEmpty) ? $configuration.IncrementalPrerelease -eq 'true' : $env:IncrementalPrerelease -eq 'true'
+$versionPrefix = ($configuration.VersionPrefix | IsNotNullOrEmpty) ? $configuration.VersionPrefix : $env:VersionPrefix
 
 Write-Output '-------------------------------------------------'
 Write-Output "Auto cleanup enabled:           [$autoCleanup]"

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -122,7 +122,7 @@ if ($createPrerelease -or $createRelease) {
         Write-Error 'Failed to list all releases for the repo.'
         exit $LASTEXITCODE
     }
-    $releases | Select-Object -Property name, isDraft, isPrerelease, isLatest, publishedAt, createdAt | Format-Table
+    $releases | Select-Object -Property name, isPrerelease, isLatest, publishedAt | Format-Table
     Write-Output '::endgroup::'
 
     Write-Output '::group::Get latest version'
@@ -180,7 +180,7 @@ if ($createPrerelease -or $createRelease) {
 
         if ($incrementalPrerelease) {
             $prereleases = $releases | Where-Object { $_.tagName -like "$newVersion*" } | ForEach-Object {
-                $_ | Add-Member -MemberType NoteProperty -Name 'number' -Value ($_.tagName -Split '.')[-1] -PassThru
+                $_ | Add-Member -MemberType NoteProperty -Name 'number' -Value ($_.tagName -Split '\.')[-1] -PassThru -Force
             } | Sort-Object -Property number -Descending
             $prereleases | Select-Object -Property number, name, publishedAt, isPrerelease, isLatest | Format-Table
 

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -180,7 +180,7 @@ if ($createPrerelease -or $createRelease) {
 
         if ($incrementalPrerelease) {
             $prereleases = $releases | Where-Object { $_.tagName -like "$newVersion*" } | ForEach-Object {
-                $_ | Add-Member -MemberType  -Name 'number' -Value [int](($_.tagName -Split '\.')[-1]) -TypeName int -PassThru -Force
+                $_ | Add-Member -MemberType NoteProperty -Name 'number' -Value [int](($_.tagName -Split '\.')[-1]) -TypeName int -PassThru -Force
             } | Sort-Object -Property number -Descending
             $prereleases | Select-Object -Property number, name, publishedAt, isPrerelease, isLatest | Format-Table
 

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -180,7 +180,7 @@ if ($createPrerelease -or $createRelease) {
 
         if ($incrementalPrerelease) {
             $prereleases = $releases | Where-Object { $_.tagName -like "$newVersion*" } | ForEach-Object {
-                $_ | Add-Member -MemberType NoteProperty -Name 'number' -Value [int]($_.tagName -Split '\.')[-1] -TypeName int -PassThru -Force
+                $_ | Add-Member -MemberType NoteProperty -Name 'number' -Value [int](($_.tagName -Split '\.')[-1]) -TypeName int -PassThru -Force
             } | Sort-Object -Property number -Descending
             $prereleases | Select-Object -Property number, name, publishedAt, isPrerelease, isLatest | Format-Table
 

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -251,8 +251,6 @@ if ($createPrerelease -or $createRelease) {
 }
 
 Write-Output "::notice::Release created: [$newVersion]"
-Write-Output "::warning::Release created: [$newVersion]"
-Write-Output "::error::Release created: [$newVersion]"
 
 Write-Output '::group::List prereleases using the same name'
 $prereleasesToCleanup = $releases | Where-Object { $_.tagName -like "*$preReleaseName*" }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -106,7 +106,6 @@ $majorRelease = (Compare-Object -ReferenceObject $labels -DifferenceObject $majo
 $minorRelease = (Compare-Object -ReferenceObject $labels -DifferenceObject $minorTags -IncludeEqual -ExcludeDifferent).Count -gt 0 -and -not $majorRelease
 $patchRelease = (Compare-Object -ReferenceObject $labels -DifferenceObject $patchTags -IncludeEqual -ExcludeDifferent).Count -gt 0 -and -not $majorRelease -and -not $minorRelease
 
-
 Write-Output '-------------------------------------------------'
 Write-Output "Create a release:               [$createRelease]"
 Write-Output "Create a prerelease:            [$createPrerelease]"


### PR DESCRIPTION
- Fixes #4, by introducing a new parameter `ConfigurationFile` which takes the path to the config file in the calling repo.

Bug fixes:
- Fixes an issue that would fail when creating the 11th incremental prerelease. Sorting was done on `tagName`. This cause the sorting to not sort `*.10` at the end, leaving `*.9` as the last prerelease, and trying to publish a `*.10` again. Changed to sorting on the incremental `number` of the tag name.
- Fixes an issue that would create a prerelease even when a PR gets closed, leaving the latest prerelease in place after automatic cleanup.