### PR TITLE
🪲[Fix] Prerelease tags set to head commit

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -210,7 +210,7 @@ if ($createPrerelease -or $createRelease) {
             }
         }
 
-        gh release create $newVersion --title $newVersion --generate-notes --prerelease
+        gh release create $newVersion --title $newVersion --target $pull_request.head.ref --generate-notes --prerelease
         if ($LASTEXITCODE -ne 0) {
             Write-Error "Failed to create the release [$newVersion]."
             exit $LASTEXITCODE

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -88,7 +88,7 @@ $pull_request | Format-List
 Write-Output '::endgroup::'
 
 Write-Output '::group::Pull request - Labels'
-$labels = @()
+$labels = @('')
 $labels += $pull_request.labels.name
 $labels | Format-List
 Write-Output '::endgroup::'


### PR DESCRIPTION
- Fix so prerelease tags are set on the head branch, was `main` as per default in `gh release create`.