### PR TITLE
🪲[Fix] Workflow fails when no labels are provided

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -88,7 +88,7 @@ $pull_request | Format-List
 Write-Output '::endgroup::'
 
 Write-Output '::group::Pull request - Labels'
-$labels = @()
+$labels = @('')
 $labels += $pull_request.labels.name
 $labels | Format-List
 Write-Output '::endgroup::'


### PR DESCRIPTION
- Fixes an issue when labels on a pr are not provided.