### PR TITLE
🚀[Feature] Custom release type labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ The action have the following parameters:
 | `CreateMinorTag` | Control wether to create a tag for minor releases. | `true` | false |
 | `DatePrereleaseFormat` | The format to use for the prerelease number using [.NET DateTime format strings](https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings). | `''` | false |
 | `IncrementalPrerelease` | Control wether to automatically increment the prerelease number. If disabled, the action will ensure only one prerelease exists for a given branch. | `true` | false |
+| `MajorLabels` | The labels to use for major releases. | `major, breaking` | false |
+| `MinorLabels` | The labels to use for minor releases. | `minor, feature, improvement` | false |
+| `PatchLabels` | The labels to use for patch releases. | `patch, fix, bug` | false |
 | `VersionPrefix` | The prefix to use for the version number. | `v` | false |
 
 ### Configuration file

--- a/action.yml
+++ b/action.yml
@@ -34,10 +34,6 @@ inputs:
     description: Control wether to automatically increment the prerelease number. If disabled, the action will ensure only one prerelease exists for a given branch.
     required: false
     default: 'true'
-  VersionPrefix:
-    description: The prefix to use for the version number.
-    required: false
-    default: 'v'
   MajorLabels:
     description: The labels to use for major releases.
     required: false
@@ -50,6 +46,10 @@ inputs:
     description: The labels to use for patch releases.
     required: false
     default: 'patch, fix, bug'
+  VersionPrefix:
+    description: The prefix to use for the version number.
+    required: false
+    default: 'v'
 
 runs:
   using: composite

--- a/action.yml
+++ b/action.yml
@@ -56,13 +56,4 @@ runs:
   steps:
     - name: Auto-Release
       shell: pwsh
-      env:
-        AutoCleanup: ${{ inputs.AutoCleanup }}
-        AutoPatching: ${{ inputs.AutoPatching }}
-        ConfigurationFile: ${{ inputs.ConfigurationFile }}
-        CreateMajorTag: ${{ inputs.CreateMajorTag }}
-        CreateMinorTag: ${{ inputs.CreateMinorTag }}
-        DatePrereleaseFormat: ${{ inputs.DatePrereleaseFormat }}
-        IncrementalPrerelease: ${{ inputs.IncrementalPrerelease }}
-        VersionPrefix: ${{ inputs.VersionPrefix }}
       run: . "$env:GITHUB_ACTION_PATH\scripts\main.ps1"

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,18 @@ inputs:
     description: The prefix to use for the version number.
     required: false
     default: 'v'
+  MajorLabels:
+    description: The labels to use for major releases.
+    required: false
+    default: 'major, breaking'
+  MinorLabels:
+    description: The labels to use for minor releases.
+    required: false
+    default: 'minor, feature, improvement'
+  PatchLabels:
+    description: The labels to use for patch releases.
+    required: false
+    default: 'patch, fix, bug'
 
 runs:
   using: composite

--- a/action.yml
+++ b/action.yml
@@ -56,4 +56,16 @@ runs:
   steps:
     - name: Auto-Release
       shell: pwsh
+      env:
+        AutoCleanup: ${{ inputs.AutoCleanup }}
+        AutoPatching: ${{ inputs.AutoPatching }}
+        ConfigurationFile: ${{ inputs.ConfigurationFile }}
+        CreateMajorTag: ${{ inputs.CreateMajorTag }}
+        CreateMinorTag: ${{ inputs.CreateMinorTag }}
+        DatePrereleaseFormat: ${{ inputs.DatePrereleaseFormat }}
+        IncrementalPrerelease: ${{ inputs.IncrementalPrerelease }}
+        MajorLabels: ${{ inputs.MajorLabels }}
+        MinorLabels: ${{ inputs.MinorLabels }}
+        PatchLabels: ${{ inputs.PatchLabels }}
+        VersionPrefix: ${{ inputs.VersionPrefix }}
       run: . "$env:GITHUB_ACTION_PATH\scripts\main.ps1"

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -44,6 +44,10 @@ $datePrereleaseFormat = ($configuration.DatePrereleaseFormat | IsNotNullOrEmpty)
 $incrementalPrerelease = ($configuration.IncrementalPrerelease | IsNotNullOrEmpty) ? $configuration.IncrementalPrerelease -eq 'true' : $env:IncrementalPrerelease -eq 'true'
 $versionPrefix = ($configuration.VersionPrefix | IsNotNullOrEmpty) ? $configuration.VersionPrefix : $env:VersionPrefix
 
+$majorLabels = (($configuration.MajorLabels | IsNotNullOrEmpty) ? $configuration.MajorLabels : $env:MajorLabels) -split ','
+$minorLabels = (($configuration.MinorLabels | IsNotNullOrEmpty) ? $configuration.MinorLabels : $env:MinorLabels) -split ','
+$patchLabels = (($configuration.PatchLabels | IsNotNullOrEmpty) ? $configuration.PatchLabels : $env:PatchLabels) -split ','
+
 Write-Output '-------------------------------------------------'
 Write-Output "Auto cleanup enabled:           [$autoCleanup]"
 Write-Output "Auto patching enabled:          [$autoPatching]"
@@ -52,6 +56,10 @@ Write-Output "Create minor tag enabled:       [$createMinorTag]"
 Write-Output "Date-based prerelease format:   [$datePrereleaseFormat]"
 Write-Output "Incremental prerelease enabled: [$incrementalPrerelease]"
 Write-Output "Version prefix:                 [$versionPrefix]"
+Write-Output ''
+Write-Output "Major labels:                   [$($majorLabels -join ', ')]"
+Write-Output "Minor labels:                   [$($minorLabels -join ', ')]"
+Write-Output "Patch labels:                   [$($patchLabels -join ', ')]"
 Write-Output '-------------------------------------------------'
 Write-Output '::endgroup::'
 
@@ -92,10 +100,6 @@ $labels = @()
 $labels += $pull_request.labels.name
 $labels | Format-List
 Write-Output '::endgroup::'
-
-$majorLabels = @('major', 'breaking')
-$minorLabels = @('minor', 'feature', 'improvement')
-$patchLabels = @('patch', 'fix', 'bug')
 
 $createRelease = $pull_request.base.ref -eq 'main' -and ($pull_request.merged).ToString() -eq 'True'
 $closedPullRequest = $pull_request.state -eq 'closed' -and ($pull_request.merged).ToString() -eq 'False'

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -44,9 +44,9 @@ $datePrereleaseFormat = ($configuration.DatePrereleaseFormat | IsNotNullOrEmpty)
 $incrementalPrerelease = ($configuration.IncrementalPrerelease | IsNotNullOrEmpty) ? $configuration.IncrementalPrerelease -eq 'true' : $env:IncrementalPrerelease -eq 'true'
 $versionPrefix = ($configuration.VersionPrefix | IsNotNullOrEmpty) ? $configuration.VersionPrefix : $env:VersionPrefix
 
-$majorLabels = (($configuration.MajorLabels | IsNotNullOrEmpty) ? $configuration.MajorLabels : $env:MajorLabels) -split ','
-$minorLabels = (($configuration.MinorLabels | IsNotNullOrEmpty) ? $configuration.MinorLabels : $env:MinorLabels) -split ','
-$patchLabels = (($configuration.PatchLabels | IsNotNullOrEmpty) ? $configuration.PatchLabels : $env:PatchLabels) -split ','
+$majorLabels = (($configuration.MajorLabels | IsNotNullOrEmpty) ? $configuration.MajorLabels : $env:MajorLabels) -split ',' | ForEach-Object { $_.Trim() }
+$minorLabels = (($configuration.MinorLabels | IsNotNullOrEmpty) ? $configuration.MinorLabels : $env:MinorLabels) -split ',' | ForEach-Object { $_.Trim() }
+$patchLabels = (($configuration.PatchLabels | IsNotNullOrEmpty) ? $configuration.PatchLabels : $env:PatchLabels) -split ',' | ForEach-Object { $_.Trim() }
 
 Write-Output '-------------------------------------------------'
 Write-Output "Auto cleanup enabled:           [$autoCleanup]"


### PR DESCRIPTION
- Fixes #13, by introducing new settings called `MajorLabels`, `MinorLabels` and `PatchLabels`. These settings take a comma separated list of label names that would trigger the type of release.