### PR TITLE
🪲[Fix] Workflow permissions to post comment on PR

### DIFF
--- a/.github/workflows/Auto-Release.yml
+++ b/.github/workflows/Auto-Release.yml
@@ -18,6 +18,7 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   Auto-Release:

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -229,6 +229,16 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
                 exit $LASTEXITCODE
             }
         }
+
+        if ($whatIf) {
+            Write-Output 'WhatIf: gh pr comment $pull_request.number -b "The release [$newVersion] has been created."'
+        } else {
+            gh pr comment $pull_request.number -b "The release [$newVersion] has been created."
+            if ($LASTEXITCODE -ne 0) {
+                Write-Error "Failed to comment on the pull request."
+                exit $LASTEXITCODE
+            }
+        }
     } else {
         if ($whatIf) {
             Write-Output "WhatIf: gh release create $newVersion --title $newVersion --generate-notes"


### PR DESCRIPTION
- Fixes an issue with workflows not having access to comment PRs when it creates a prerelease.