### PR TITLE
🪲[Fix] Remove invalid prefix on `GITHUB_EVENT_PATH`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,19 +65,19 @@ runs:
     - name: Auto-Release
       shell: pwsh
       env:
-        AutoCleanup: ${{ inputs.AutoCleanup }}
-        AutoPatching: ${{ inputs.AutoPatching }}
-        ConfigurationFile: ${{ inputs.ConfigurationFile }}
-        CreateMajorTag: ${{ inputs.CreateMajorTag }}
-        CreateMinorTag: ${{ inputs.CreateMinorTag }}
-        DatePrereleaseFormat: ${{ inputs.DatePrereleaseFormat }}
-        IgnoreLabels: ${{ inputs.IgnoreLabels }}
-        IncrementalPrerelease: ${{ inputs.IncrementalPrerelease }}
-        MajorLabels: ${{ inputs.MajorLabels }}
-        MinorLabels: ${{ inputs.MinorLabels }}
-        PatchLabels: ${{ inputs.PatchLabels }}
-        VersionPrefix: ${{ inputs.VersionPrefix }}
-        WhatIf: ${{ inputs.WhatIf }}
+        GITHUB_ACTION_INPUT_AutoCleanup: ${{ inputs.AutoCleanup }}
+        GITHUB_ACTION_INPUT_AutoPatching: ${{ inputs.AutoPatching }}
+        GITHUB_ACTION_INPUT_ConfigurationFile: ${{ inputs.ConfigurationFile }}
+        GITHUB_ACTION_INPUT_CreateMajorTag: ${{ inputs.CreateMajorTag }}
+        GITHUB_ACTION_INPUT_CreateMinorTag: ${{ inputs.CreateMinorTag }}
+        GITHUB_ACTION_INPUT_DatePrereleaseFormat: ${{ inputs.DatePrereleaseFormat }}
+        GITHUB_ACTION_INPUT_IgnoreLabels: ${{ inputs.IgnoreLabels }}
+        GITHUB_ACTION_INPUT_IncrementalPrerelease: ${{ inputs.IncrementalPrerelease }}
+        GITHUB_ACTION_INPUT_MajorLabels: ${{ inputs.MajorLabels }}
+        GITHUB_ACTION_INPUT_MinorLabels: ${{ inputs.MinorLabels }}
+        GITHUB_ACTION_INPUT_PatchLabels: ${{ inputs.PatchLabels }}
+        GITHUB_ACTION_INPUT_VersionPrefix: ${{ inputs.VersionPrefix }}
+        GITHUB_ACTION_INPUT_WhatIf: ${{ inputs.WhatIf }}
       run: |
         # Auto-Release
         Write-Host '::group::Loading libraries'

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -47,7 +47,7 @@ Write-Output '-------------------------------------------------'
 Stop-LogGroup
 
 Start-LogGroup 'Event information - JSON'
-$githubEventJson = Get-Content $env:GITHUB_ACTION_INPUT_GITHUB_EVENT_PATH
+$githubEventJson = Get-Content $env:GITHUB_EVENT_PATH
 $githubEventJson | Format-List
 Stop-LogGroup
 

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -8,26 +8,26 @@ Get-ChildItem -Path Env: | Select-Object Name, Value | Sort-Object Name | Format
 Stop-LogGroup
 
 Start-LogGroup 'Set configuration'
-if (-not (Test-Path -Path $env:ConfigurationFile -PathType Leaf)) {
-    Write-Output "Configuration file not found at [$env:ConfigurationFile]"
+if (-not (Test-Path -Path $env:GITHUB_ACTION_INPUT_ConfigurationFile -PathType Leaf)) {
+    Write-Output "Configuration file not found at [$env:GITHUB_ACTION_INPUT_ConfigurationFile]"
 } else {
-    Write-Output "Reading from configuration file [$env:ConfigurationFile]"
-    $configuration = ConvertFrom-Yaml -Yaml (Get-Content $env:ConfigurationFile -Raw)
+    Write-Output "Reading from configuration file [$env:GITHUB_ACTION_INPUT_ConfigurationFile]"
+    $configuration = ConvertFrom-Yaml -Yaml (Get-Content $env:GITHUB_ACTION_INPUT_ConfigurationFile -Raw)
 }
 
-$autoCleanup = ($configuration.AutoCleanup | IsNotNullOrEmpty) ? $configuration.AutoCleanup -eq 'true' : $env:AutoCleanup -eq 'true'
-$autoPatching = ($configuration.AutoPatching | IsNotNullOrEmpty) ? $configuration.AutoPatching -eq 'true' : $env:AutoPatching -eq 'true'
-$createMajorTag = ($configuration.CreateMajorTag | IsNotNullOrEmpty) ? $configuration.CreateMajorTag -eq 'true' : $env:CreateMajorTag -eq 'true'
-$createMinorTag = ($configuration.CreateMinorTag | IsNotNullOrEmpty) ? $configuration.CreateMinorTag -eq 'true' : $env:CreateMinorTag -eq 'true'
-$datePrereleaseFormat = ($configuration.DatePrereleaseFormat | IsNotNullOrEmpty) ? $configuration.DatePrereleaseFormat : $env:DatePrereleaseFormat
-$incrementalPrerelease = ($configuration.IncrementalPrerelease | IsNotNullOrEmpty) ? $configuration.IncrementalPrerelease -eq 'true' : $env:IncrementalPrerelease -eq 'true'
-$versionPrefix = ($configuration.VersionPrefix | IsNotNullOrEmpty) ? $configuration.VersionPrefix : $env:VersionPrefix
-$whatIf = ($configuration.WhatIf | IsNotNullOrEmpty) ? $configuration.WhatIf -eq 'true' : $env:WhatIf -eq 'true'
+$autoCleanup = ($configuration.AutoCleanup | IsNotNullOrEmpty) ? $configuration.AutoCleanup -eq 'true' : $env:GITHUB_ACTION_INPUT_AutoCleanup -eq 'true'
+$autoPatching = ($configuration.AutoPatching | IsNotNullOrEmpty) ? $configuration.AutoPatching -eq 'true' : $env:GITHUB_ACTION_INPUT_AutoPatching -eq 'true'
+$createMajorTag = ($configuration.CreateMajorTag | IsNotNullOrEmpty) ? $configuration.CreateMajorTag -eq 'true' : $env:GITHUB_ACTION_INPUT_CreateMajorTag -eq 'true'
+$createMinorTag = ($configuration.CreateMinorTag | IsNotNullOrEmpty) ? $configuration.CreateMinorTag -eq 'true' : $env:GITHUB_ACTION_INPUT_CreateMinorTag -eq 'true'
+$datePrereleaseFormat = ($configuration.DatePrereleaseFormat | IsNotNullOrEmpty) ? $configuration.DatePrereleaseFormat : $env:GITHUB_ACTION_INPUT_DatePrereleaseFormat
+$incrementalPrerelease = ($configuration.IncrementalPrerelease | IsNotNullOrEmpty) ? $configuration.IncrementalPrerelease -eq 'true' : $env:GITHUB_ACTION_INPUT_IncrementalPrerelease -eq 'true'
+$versionPrefix = ($configuration.VersionPrefix | IsNotNullOrEmpty) ? $configuration.VersionPrefix : $env:GITHUB_ACTION_INPUT_VersionPrefix
+$whatIf = ($configuration.WhatIf | IsNotNullOrEmpty) ? $configuration.WhatIf -eq 'true' : $env:GITHUB_ACTION_INPUT_WhatIf -eq 'true'
 
-$ignoreLabels = (($configuration.IgnoreLabels | IsNotNullOrEmpty) ? $configuration.IgnoreLabels : $env:IgnoreLabels) -split ',' | ForEach-Object { $_.Trim() }
-$majorLabels = (($configuration.MajorLabels | IsNotNullOrEmpty) ? $configuration.MajorLabels : $env:MajorLabels) -split ',' | ForEach-Object { $_.Trim() }
-$minorLabels = (($configuration.MinorLabels | IsNotNullOrEmpty) ? $configuration.MinorLabels : $env:MinorLabels) -split ',' | ForEach-Object { $_.Trim() }
-$patchLabels = (($configuration.PatchLabels | IsNotNullOrEmpty) ? $configuration.PatchLabels : $env:PatchLabels) -split ',' | ForEach-Object { $_.Trim() }
+$ignoreLabels = (($configuration.IgnoreLabels | IsNotNullOrEmpty) ? $configuration.IgnoreLabels : $env:GITHUB_ACTION_INPUT_IgnoreLabels) -split ',' | ForEach-Object { $_.Trim() }
+$majorLabels = (($configuration.MajorLabels | IsNotNullOrEmpty) ? $configuration.MajorLabels : $env:GITHUB_ACTION_INPUT_MajorLabels) -split ',' | ForEach-Object { $_.Trim() }
+$minorLabels = (($configuration.MinorLabels | IsNotNullOrEmpty) ? $configuration.MinorLabels : $env:GITHUB_ACTION_INPUT_MinorLabels) -split ',' | ForEach-Object { $_.Trim() }
+$patchLabels = (($configuration.PatchLabels | IsNotNullOrEmpty) ? $configuration.PatchLabels : $env:GITHUB_ACTION_INPUT_PatchLabels) -split ',' | ForEach-Object { $_.Trim() }
 
 Write-Output '-------------------------------------------------'
 Write-Output "Auto cleanup enabled:           [$autoCleanup]"
@@ -47,7 +47,7 @@ Write-Output '-------------------------------------------------'
 Stop-LogGroup
 
 Start-LogGroup 'Event information - JSON'
-$githubEventJson = Get-Content $env:GITHUB_EVENT_PATH
+$githubEventJson = Get-Content $env:GITHUB_ACTION_INPUT_GITHUB_EVENT_PATH
 $githubEventJson | Format-List
 Stop-LogGroup
 


### PR DESCRIPTION
- Removes an invalid prefix on `GITHUB_EVENT_PATH`