### PR TITLE
🩹 [Patch]: Use the `PSSemVer` module

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,7 @@ runs:
       run: |
         # Auto-Release
         Write-Host '::group::Loading libraries'
-        Install-PSResource -Name 'Utilities', 'powershell-yaml' -TrustRepository -Verbose
+        Install-PSResource -Name 'Utilities', 'powershell-yaml', 'PSSemVer' -TrustRepository -Verbose
         Write-Host '::endgroup::'
 
         . "$env:GITHUB_ACTION_PATH\scripts\main.ps1" -Verbose

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -1,4 +1,4 @@
-﻿#REQUIRES -Modules Utilities, powershell-yaml
+﻿#REQUIRES -Modules Utilities, powershell-yaml, PSSemVer
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
     'PSAvoidLongLines', '', Justification = 'Long ternary operators are used for readability.'
@@ -141,7 +141,7 @@ $latestRelease = $releases | Where-Object { $_.isLatest -eq $true }
 $latestRelease | Format-List
 $latestVersionString = $latestRelease.tagName
 if ($latestVersionString | IsNotNullOrEmpty) {
-    $latestVersion = $latestVersionString | ConvertTo-SemVer
+    $latestVersion = $latestVersionString | ConvertTo-PSSemVer
     Write-Output '-------------------------------------------------'
     Write-Output 'Latest version:'
     $latestVersion | Format-Table
@@ -157,8 +157,8 @@ Write-Output '-------------------------------------------------'
 #region Create a new version
 if ($createPrerelease -or $createRelease -or $whatIf) {
     Start-LogGroup 'Calculate new version'
-    $latestVersion = New-SemVer -Version $latestVersion
-    $newVersion = New-SemVer -Version $latestVersion
+    $latestVersion = New-PSSemVer -Version $latestVersion
+    $newVersion = New-PSSemVer -Version $latestVersion
     $newVersion.Prefix = $versionPrefix
     if ($majorRelease) {
         Write-Output 'Incrementing major version.'


### PR DESCRIPTION
## Description

- Use the `PSSemVer` module, instead of the PSSemVer class in `Utilities`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
