### PR TITLE
🩹 [Patch]: Update linter config and clean up call to `main.ps1`

### DIFF
--- a/.github/linters/.jscpd.json
+++ b/.github/linters/.jscpd.json
@@ -4,7 +4,7 @@
         "consoleFull"
     ],
     "ignore": [
-        "**/tests/*"
+        "**/tests/**"
     ],
     "absolute": true
 }

--- a/.github/linters/.powershell-psscriptanalyzer.psd1
+++ b/.github/linters/.powershell-psscriptanalyzer.psd1
@@ -51,7 +51,6 @@
     }
     ExcludeRules = @(
         'PSMissingModuleManifestField', # This rule is not applicable until the module is built.
-        'PSAvoidUsingCmdletAliases',
         'PSUseToExportFieldsInManifest'
     )
 }

--- a/action.yml
+++ b/action.yml
@@ -81,4 +81,4 @@ runs:
       with:
         Script: |
           # Auto-Release
-          '${{ github.action_path }}\scripts\main.ps1'
+          ${{ github.action_path }}\scripts\main.ps1

--- a/action.yml
+++ b/action.yml
@@ -81,4 +81,4 @@ runs:
       with:
         Script: |
           # Auto-Release
-          . "${{ github.action_path }}\scripts\main.ps1"
+          '${{ github.action_path }}\scripts\main.ps1'


### PR DESCRIPTION
## Description

This pull request includes several updates to configuration files and script references. The changes primarily focus on improving file path patterns, updating rule exclusions, and modifying script invocation methods.

Configuration updates:

* [`.github/linters/.jscpd.json`](diffhunk://#diff-557094e283c00b23265c1c75872f41c6b1a524a00f0d99dd68ebd22cb63bfdd6L7-R7): Adjusted the `ignore` pattern to include all subdirectories within `tests`.
* [`.github/linters/.powershell-psscriptanalyzer.psd1`](diffhunk://#diff-aae69c9d6774628ed181eacf53aee0f38eb6c2f53492cf3a5b7f7bdb6ef43b6aL54): Removed the exclusion of the `PSAvoidUsingCmdletAliases` rule.

Script invocation update:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L84-R84): Changed the script invocation method for `main.ps1` to use a direct path reference.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
