### PR TITLE
🩹 [Patch]: Remove GITHUB_TOKEN environment variable, its already in the Github-Script

### DIFF
--- a/.github/workflows/Auto-Release.yml
+++ b/.github/workflows/Auto-Release.yml
@@ -30,7 +30,5 @@ jobs:
 
       - name: Auto-Release
         uses: ./
-        env:
-          GITHUB_TOKEN: ${{ github.token }} # Used for GitHub CLI authentication
         with:
           IncrementalPrerelease: false


### PR DESCRIPTION
## Description

This pull request includes a small change to the `.github/workflows/Auto-Release.yml` file. The change removes the `env` section that contained the `GITHUB_TOKEN` used for GitHub CLI authentication. This is already included in the GitHub-Script, so the `env` section is no longer needed.

* [`.github/workflows/Auto-Release.yml`](diffhunk://#diff-d3f6900ee5159d4bc4ba6d893e2dd8443c2691b0490d7351cffbd7a37ed8d95aL33-L34): Removed the `env` section containing `GITHUB_TOKEN` used for GitHub CLI authentication.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
