### PR TITLE
🚀 [Feature]: Add options to use PR title and body as release title and body

### DIFF
--- a/.github/linters/.jscpd.json
+++ b/.github/linters/.jscpd.json
@@ -4,7 +4,8 @@
         "consoleFull"
     ],
     "ignore": [
-        "**/tests/**"
+        "**/tests/**",
+        "**/scripts/**"
     ],
     "absolute": true
 }

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ The action can be configured using the following settings:
 | `MajorLabels` | A comma separated list of labels that trigger a major release. | `major, breaking` | false |
 | `MinorLabels` | A comma separated list of labels that trigger a minor release. | `minor, feature` | false |
 | `PatchLabels` | A comma separated list of labels that trigger a patch release. | `patch, fix` | false |
+| `UsePRTitleAsReleaseName` | When enabled, uses the pull request title as the name for the GitHub release. | `false` | false |
 | `UsePRBodyAsReleaseNotes` | When enabled, uses the pull request body as the release notes for the GitHub release. | `true` | false |
-| `UsePRTitleAsReleaseName` | When enabled, uses the pull request title as the name for the GitHub release. | `true` | false |
 | `VersionPrefix` | The prefix to use for the version number. | `v` | false |
 | `WhatIf` | Control wether to simulate the action. If enabled, the action will not create any releases. Used for testing. | `false` | false |
 | `Debug` | Enable debug output. | `'false'` | false |

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The action can be configured using the following settings:
 | `MajorLabels` | A comma separated list of labels that trigger a major release. | `major, breaking` | false |
 | `MinorLabels` | A comma separated list of labels that trigger a minor release. | `minor, feature` | false |
 | `PatchLabels` | A comma separated list of labels that trigger a patch release. | `patch, fix` | false |
+| `UsePRBodyAsReleaseNotes` | When enabled, uses the pull request body as the release notes for the GitHub release. | `false` | false |
+| `UsePRTitleAsReleaseName` | When enabled, uses the pull request title as the name for the GitHub release. | `false` | false |
 | `VersionPrefix` | The prefix to use for the version number. | `v` | false |
 | `WhatIf` | Control wether to simulate the action. If enabled, the action will not create any releases. Used for testing. | `false` | false |
 | `Debug` | Enable debug output. | `'false'` | false |

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ The action can be configured using the following settings:
 | `MajorLabels` | A comma separated list of labels that trigger a major release. | `major, breaking` | false |
 | `MinorLabels` | A comma separated list of labels that trigger a minor release. | `minor, feature` | false |
 | `PatchLabels` | A comma separated list of labels that trigger a patch release. | `patch, fix` | false |
-| `UsePRBodyAsReleaseNotes` | When enabled, uses the pull request body as the release notes for the GitHub release. | `false` | false |
-| `UsePRTitleAsReleaseName` | When enabled, uses the pull request title as the name for the GitHub release. | `false` | false |
+| `UsePRBodyAsReleaseNotes` | When enabled, uses the pull request body as the release notes for the GitHub release. | `true` | false |
+| `UsePRTitleAsReleaseName` | When enabled, uses the pull request title as the name for the GitHub release. | `true` | false |
 | `VersionPrefix` | The prefix to use for the version number. | `v` | false |
 | `WhatIf` | Control wether to simulate the action. If enabled, the action will not create any releases. Used for testing. | `false` | false |
 | `Debug` | Enable debug output. | `'false'` | false |

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,14 @@ inputs:
     description: A comma separated list of labels that trigger a patch release.
     required: false
     default: patch, fix
+  UsePRBodyAsReleaseNotes:
+    description: When enabled, uses the pull request body as the release notes for the GitHub release.
+    required: false
+    default: 'false'
+  UsePRTitleAsReleaseName:
+    description: When enabled, uses the pull request title as the name for the GitHub release.
+    required: false
+    default: 'false'
   VersionPrefix:
     description: The prefix to use for the version number.
     required: false
@@ -95,6 +103,8 @@ runs:
         PSMODULE_AUTO_RELEASE_INPUT_MajorLabels: ${{ inputs.MajorLabels }}
         PSMODULE_AUTO_RELEASE_INPUT_MinorLabels: ${{ inputs.MinorLabels }}
         PSMODULE_AUTO_RELEASE_INPUT_PatchLabels: ${{ inputs.PatchLabels }}
+        PSMODULE_AUTO_RELEASE_INPUT_UsePRBodyAsReleaseNotes: ${{ inputs.UsePRBodyAsReleaseNotes }}
+        PSMODULE_AUTO_RELEASE_INPUT_UsePRTitleAsReleaseName: ${{ inputs.UsePRTitleAsReleaseName }}
         PSMODULE_AUTO_RELEASE_INPUT_VersionPrefix: ${{ inputs.VersionPrefix }}
         PSMODULE_AUTO_RELEASE_INPUT_WhatIf: ${{ inputs.WhatIf }}
       with:

--- a/action.yml
+++ b/action.yml
@@ -53,11 +53,11 @@ inputs:
   UsePRBodyAsReleaseNotes:
     description: When enabled, uses the pull request body as the release notes for the GitHub release.
     required: false
-    default: 'false'
+    default: 'true'
   UsePRTitleAsReleaseName:
     description: When enabled, uses the pull request title as the name for the GitHub release.
     required: false
-    default: 'false'
+    default: 'true'
   VersionPrefix:
     description: The prefix to use for the version number.
     required: false

--- a/action.yml
+++ b/action.yml
@@ -50,12 +50,12 @@ inputs:
     description: A comma separated list of labels that trigger a patch release.
     required: false
     default: patch, fix
-  UsePRBodyAsReleaseNotes:
-    description: When enabled, uses the pull request body as the release notes for the GitHub release.
-    required: false
-    default: 'true'
   UsePRTitleAsReleaseName:
     description: When enabled, uses the pull request title as the name for the GitHub release.
+    required: false
+    default: 'false'
+  UsePRBodyAsReleaseNotes:
+    description: When enabled, uses the pull request body as the release notes for the GitHub release.
     required: false
     default: 'true'
   VersionPrefix:

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -231,34 +231,34 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
             }
 
             # Build release creation command with options
-            $releaseCreateCommand = "release create $newVersion"
+            $releaseCreateCommand = @("gh", "release", "create", "$newVersion")
 
             # Add title parameter
             if ($usePRTitleAsReleaseName) {
                 $prTitle = $pull_request.title
-                $releaseCreateCommand += " --title '$prTitle'"
+                $releaseCreateCommand += @(" --title", "'$prTitle'")
                 Write-Output "Using PR title as release name: [$prTitle]"
             } else {
-                $releaseCreateCommand += " --title $newVersion"
+                $releaseCreateCommand += @(" --title", "$newVersion")
             }
 
             # Add notes parameter
             if ($usePRBodyAsReleaseNotes) {
                 $prBody = $pull_request.body
-                $releaseCreateCommand += " --notes '$prBody'"
+                $releaseCreateCommand += @(" --notes", "'$prBody'")
                 Write-Output 'Using PR body as release notes'
             } else {
                 $releaseCreateCommand += ' --generate-notes'
             }
 
             # Add remaining parameters
-            $releaseCreateCommand += " --target $prHeadRef --prerelease"
+            $releaseCreateCommand += @("--target", $prHeadRef, "--prerelease")
 
             if ($whatIf) {
                 Write-Output "WhatIf: $releaseCreateCommand"
             } else {
                 # Execute the command and capture the output
-                $releaseURL = gh $releaseCreateCommand
+                $releaseURL = & $releaseCreateCommand
                 if ($LASTEXITCODE -ne 0) {
                     Write-Error "Failed to create the release [$newVersion]."
                     exit $LASTEXITCODE
@@ -276,31 +276,31 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
             }
         } else {
             # Build release creation command with options
-            $releaseCreateCommand = "release create $newVersion"
+            $releaseCreateCommand = @("gh", "release", "create", "$newVersion")
 
             # Add title parameter
             if ($usePRTitleAsReleaseName) {
                 $prTitle = $pull_request.title
-                $releaseCreateCommand += " --title '$prTitle'"
+                $releaseCreateCommand += @(" --title", "'$prTitle'")
                 Write-Output "Using PR title as release name: [$prTitle]"
             } else {
-                $releaseCreateCommand += " --title $newVersion"
+                $releaseCreateCommand += @(" --title", "$newVersion")
             }
 
             # Add notes parameter
             if ($usePRBodyAsReleaseNotes) {
                 $prBody = $pull_request.body
-                $releaseCreateCommand += " --notes '$prBody'"
+                $releaseCreateCommand += @(" --notes", "'$prBody'")
                 Write-Output 'Using PR body as release notes'
             } else {
-                $releaseCreateCommand += ' --generate-notes'
+                $releaseCreateCommand += '--generate-notes'
             }
 
             if ($whatIf) {
                 Write-Output "WhatIf: $releaseCreateCommand"
             } else {
                 # Execute the command
-                gh $releaseCreateCommand
+                & $releaseCreateCommand
                 if ($LASTEXITCODE -ne 0) {
                     Write-Error "Failed to create the release [$newVersion]."
                     exit $LASTEXITCODE

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -231,7 +231,7 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
             }
 
             # Build release creation command with options
-            $releaseCreateCommand = @("gh", "release", "create", "$newVersion")
+            $releaseCreateCommand = @("release", "create", "$newVersion")
 
             # Add title parameter
             if ($usePRTitleAsReleaseName) {
@@ -258,7 +258,7 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
                 Write-Output "WhatIf: $releaseCreateCommand"
             } else {
                 # Execute the command and capture the output
-                $releaseURL = Start-Process $releaseCreateCommand
+                $releaseURL = gh @releaseCreateCommand
                 if ($LASTEXITCODE -ne 0) {
                     Write-Error "Failed to create the release [$newVersion]."
                     exit $LASTEXITCODE
@@ -300,7 +300,7 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
                 Write-Output "WhatIf: $releaseCreateCommand"
             } else {
                 # Execute the command
-                Start-Process $releaseCreateCommand
+                gh @releaseCreateCommand
                 if ($LASTEXITCODE -ne 0) {
                     Write-Error "Failed to create the release [$newVersion]."
                     exit $LASTEXITCODE

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -258,7 +258,7 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
                 Write-Output "WhatIf: $releaseCreateCommand"
             } else {
                 # Execute the command and capture the output
-                $releaseURL = & $releaseCreateCommand
+                $releaseURL = Start-Process $releaseCreateCommand
                 if ($LASTEXITCODE -ne 0) {
                     Write-Error "Failed to create the release [$newVersion]."
                     exit $LASTEXITCODE
@@ -300,7 +300,7 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
                 Write-Output "WhatIf: $releaseCreateCommand"
             } else {
                 # Execute the command
-                & $releaseCreateCommand
+                Start-Process $releaseCreateCommand
                 if ($LASTEXITCODE -ne 0) {
                     Write-Error "Failed to create the release [$newVersion]."
                     exit $LASTEXITCODE

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -281,16 +281,16 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
             # Add title parameter
             if ($usePRTitleAsReleaseName) {
                 $prTitle = $pull_request.title
-                $releaseCreateCommand += @(" --title", "'$prTitle'")
+                $releaseCreateCommand += @("--title", "$prTitle")
                 Write-Output "Using PR title as release name: [$prTitle]"
             } else {
-                $releaseCreateCommand += @(" --title", "$newVersion")
+                $releaseCreateCommand += @("--title", "$newVersion")
             }
 
             # Add notes parameter
             if ($usePRBodyAsReleaseNotes) {
                 $prBody = $pull_request.body
-                $releaseCreateCommand += @(" --notes", "'$prBody'")
+                $releaseCreateCommand += @("--notes", "$prBody")
                 Write-Output 'Using PR body as release notes'
             } else {
                 $releaseCreateCommand += '--generate-notes'

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -231,7 +231,7 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
             }
 
             # Build release creation command with options
-            $releaseCreateCommand = "gh release create $newVersion"
+            $releaseCreateCommand = "release create $newVersion"
 
             # Add title parameter
             if ($usePRTitleAsReleaseName) {
@@ -258,7 +258,7 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
                 Write-Output "WhatIf: $releaseCreateCommand"
             } else {
                 # Execute the command and capture the output
-                $releaseURL = & $releaseCreateCommand
+                $releaseURL = gh $releaseCreateCommand
                 if ($LASTEXITCODE -ne 0) {
                     Write-Error "Failed to create the release [$newVersion]."
                     exit $LASTEXITCODE
@@ -276,7 +276,7 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
             }
         } else {
             # Build release creation command with options
-            $releaseCreateCommand = "gh release create $newVersion"
+            $releaseCreateCommand = "release create $newVersion"
 
             # Add title parameter
             if ($usePRTitleAsReleaseName) {
@@ -300,7 +300,7 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
                 Write-Output "WhatIf: $releaseCreateCommand"
             } else {
                 # Execute the command
-                & $releaseCreateCommand
+                gh $releaseCreateCommand
                 if ($LASTEXITCODE -ne 0) {
                     Write-Error "Failed to create the release [$newVersion]."
                     exit $LASTEXITCODE

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -276,7 +276,7 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
             }
         } else {
             # Build release creation command with options
-            $releaseCreateCommand = @("gh", "release", "create", "$newVersion")
+            $releaseCreateCommand = @("release", "create", "$newVersion")
 
             # Add title parameter
             if ($usePRTitleAsReleaseName) {

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -236,19 +236,19 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
             # Add title parameter
             if ($usePRTitleAsReleaseName) {
                 $prTitle = $pull_request.title
-                $releaseCreateCommand += @(" --title", "'$prTitle'")
+                $releaseCreateCommand += @("--title", "$prTitle")
                 Write-Output "Using PR title as release name: [$prTitle]"
             } else {
-                $releaseCreateCommand += @(" --title", "$newVersion")
+                $releaseCreateCommand += @("--title", "$newVersion")
             }
 
             # Add notes parameter
             if ($usePRBodyAsReleaseNotes) {
                 $prBody = $pull_request.body
-                $releaseCreateCommand += @(" --notes", "'$prBody'")
+                $releaseCreateCommand += @("--notes", "$prBody")
                 Write-Output 'Using PR body as release notes'
             } else {
-                $releaseCreateCommand += ' --generate-notes'
+                $releaseCreateCommand += '--generate-notes'
             }
 
             # Add remaining parameters


### PR DESCRIPTION
## Description

- Adds `UsePRBodyAsReleaseNotes` and `UsePRTitleAsReleaseName` inputs. This allow you to configure the action to copy the PR body into the release notes and/or use the PR title as the release name.
  - Fixes #72
- Changes the default behavior of the action from using the built in release note generation using the .github/release.yml instructions to use the PR body for release notes (`UsePRBodyAsReleaseNotes = true`). The release title remains as before with using the semantic‑version tag. You can opt out of this new functionality by setting the input(s) to `false`.

### 📋 How to use the new options

```yaml
steps:
  - uses: PSModule/Auto-Release@vNext
    with:
      UsePRBodyAsReleaseNotes: true   # default is true
      UsePRTitleAsReleaseName: false  # default is false
```

### ⏭️ Migration guide

Current adopters that relied on the previous default (generated changelog as release notes) should explicitly set `UsePRBodyAsReleaseNotes: false` to keep former behavior.