### PR TITLE
🚀[Feature]: Add option to use PR title heading in release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The action can be configured using the following settings:
 | `PatchLabels` | A comma separated list of labels that trigger a patch release. | `patch, fix` | false |
 | `UsePRTitleAsReleaseName` | When enabled, uses the pull request title as the name for the GitHub release. | `false` | false |
 | `UsePRBodyAsReleaseNotes` | When enabled, uses the pull request body as the release notes for the GitHub release. | `true` | false |
-| `UsePRTitleAsNotesHeading` | When enabled, the release notes will begin with the pull request title as a H2 heading followed by the pull request body. | `true` | false |
+| `UsePRTitleAsNotesHeading` | When enabled, the release notes will begin with the pull request title as an H2 heading followed by the pull request body. | `true` | false |
 | `VersionPrefix` | The prefix to use for the version number. | `v` | false |
 | `WhatIf` | Control wether to simulate the action. If enabled, the action will not create any releases. Used for testing. | `false` | false |
 | `Debug` | Enable debug output. | `'false'` | false |

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The action can be configured using the following settings:
 | `PatchLabels` | A comma separated list of labels that trigger a patch release. | `patch, fix` | false |
 | `UsePRTitleAsReleaseName` | When enabled, uses the pull request title as the name for the GitHub release. | `false` | false |
 | `UsePRBodyAsReleaseNotes` | When enabled, uses the pull request body as the release notes for the GitHub release. | `true` | false |
+| `UsePRTitleAsNotesHeading` | When enabled, the release notes will begin with the pull request title as a H2 heading followed by the pull request body. | `true` | false |
 | `VersionPrefix` | The prefix to use for the version number. | `v` | false |
 | `WhatIf` | Control wether to simulate the action. If enabled, the action will not create any releases. Used for testing. | `false` | false |
 | `Debug` | Enable debug output. | `'false'` | false |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The action can be configured using the following settings:
 | `PatchLabels` | A comma separated list of labels that trigger a patch release. | `patch, fix` | false |
 | `UsePRTitleAsReleaseName` | When enabled, uses the pull request title as the name for the GitHub release. | `false` | false |
 | `UsePRBodyAsReleaseNotes` | When enabled, uses the pull request body as the release notes for the GitHub release. | `true` | false |
-| `UsePRTitleAsNotesHeading` | When enabled, the release notes will begin with the pull request title as an H2 heading followed by the pull request body. | `true` | false |
+| `UsePRTitleAsNotesHeading` | When enabled, the release notes will begin with the pull request title as a H1 heading followed by the pull request body. The title will include a reference to the PR number. | `true` | false |
 | `VersionPrefix` | The prefix to use for the version number. | `v` | false |
 | `WhatIf` | Control wether to simulate the action. If enabled, the action will not create any releases. Used for testing. | `false` | false |
 | `Debug` | Enable debug output. | `'false'` | false |

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,10 @@ inputs:
     description: When enabled, uses the pull request body as the release notes for the GitHub release.
     required: false
     default: 'true'
+  UsePRTitleAsNotesHeading:
+    description: When enabled, the release notes will begin with the pull request title as a H2 heading followed by the pull request body.
+    required: false
+    default: 'true'
   VersionPrefix:
     description: The prefix to use for the version number.
     required: false
@@ -105,6 +109,7 @@ runs:
         PSMODULE_AUTO_RELEASE_INPUT_PatchLabels: ${{ inputs.PatchLabels }}
         PSMODULE_AUTO_RELEASE_INPUT_UsePRBodyAsReleaseNotes: ${{ inputs.UsePRBodyAsReleaseNotes }}
         PSMODULE_AUTO_RELEASE_INPUT_UsePRTitleAsReleaseName: ${{ inputs.UsePRTitleAsReleaseName }}
+        PSMODULE_AUTO_RELEASE_INPUT_UsePRTitleAsNotesHeading: ${{ inputs.UsePRTitleAsNotesHeading }}
         PSMODULE_AUTO_RELEASE_INPUT_VersionPrefix: ${{ inputs.VersionPrefix }}
         PSMODULE_AUTO_RELEASE_INPUT_WhatIf: ${{ inputs.WhatIf }}
       with:

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ inputs:
     required: false
     default: 'true'
   UsePRTitleAsNotesHeading:
-    description: When enabled, the release notes will begin with the pull request title as a H2 heading followed by the pull request body.
+    description: When enabled, the release notes will begin with the pull request title as an H2 heading followed by the pull request body.
     required: false
     default: 'true'
   VersionPrefix:

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ inputs:
     required: false
     default: 'true'
   UsePRTitleAsNotesHeading:
-    description: When enabled, the release notes will begin with the pull request title as an H2 heading followed by the pull request body.
+    description: When enabled, the release notes will begin with the pull request title as a H1 heading followed by the pull request body. The title will reference the pull request number.
     required: false
     default: 'true'
   VersionPrefix:

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -247,10 +247,11 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
             # Add notes parameter
             if ($usePRTitleAsNotesHeading) {
                 $prTitle = $pull_request.title
+                $prNumber = $pull_request.number
                 $prBody = $pull_request.body
-                $notes = "## $prTitle`n`n$prBody"
+                $notes = "# $prTitle (#$prNumber)`n`n$prBody"
                 $releaseCreateCommand += @("--notes", "$notes")
-                Write-Output 'Using PR title as H2 heading and body as release notes'
+                Write-Output 'Using PR title as H1 heading with link and body as release notes'
             } elseif ($usePRBodyAsReleaseNotes) {
                 $prBody = $pull_request.body
                 $releaseCreateCommand += @("--notes", "$prBody")
@@ -298,10 +299,11 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
             # Add notes parameter
             if ($usePRTitleAsNotesHeading) {
                 $prTitle = $pull_request.title
+                $prNumber = $pull_request.number
                 $prBody = $pull_request.body
-                $notes = "## $prTitle`n`n$prBody"
+                $notes = "# $prTitle (#$prNumber)`n`n$prBody"
                 $releaseCreateCommand += @("--notes", "$notes")
-                Write-Output 'Using PR title as H2 heading and body as release notes'
+                Write-Output 'Using PR title as H1 heading with link and body as release notes'
             } elseif ($usePRBodyAsReleaseNotes) {
                 $prBody = $pull_request.body
                 $releaseCreateCommand += @("--notes", "$prBody")

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -47,6 +47,7 @@ LogGroup 'Set configuration' {
     $incrementalPrerelease = ![string]::IsNullOrEmpty($configuration.IncrementalPrerelease) ? $configuration.IncrementalPrerelease -eq 'true' : $env:PSMODULE_AUTO_RELEASE_INPUT_IncrementalPrerelease -eq 'true'
     $usePRBodyAsReleaseNotes = ![string]::IsNullOrEmpty($configuration.UsePRBodyAsReleaseNotes) ? $configuration.UsePRBodyAsReleaseNotes -eq 'true' : $env:PSMODULE_AUTO_RELEASE_INPUT_UsePRBodyAsReleaseNotes -eq 'true'
     $usePRTitleAsReleaseName = ![string]::IsNullOrEmpty($configuration.UsePRTitleAsReleaseName) ? $configuration.UsePRTitleAsReleaseName -eq 'true' : $env:PSMODULE_AUTO_RELEASE_INPUT_UsePRTitleAsReleaseName -eq 'true'
+    $usePRTitleAsNotesHeading = ![string]::IsNullOrEmpty($configuration.UsePRTitleAsNotesHeading) ? $configuration.UsePRTitleAsNotesHeading -eq 'true' : $env:PSMODULE_AUTO_RELEASE_INPUT_UsePRTitleAsNotesHeading -eq 'true'
     $versionPrefix = ![string]::IsNullOrEmpty($configuration.VersionPrefix) ? $configuration.VersionPrefix : $env:PSMODULE_AUTO_RELEASE_INPUT_VersionPrefix
     $whatIf = ![string]::IsNullOrEmpty($configuration.WhatIf) ? $configuration.WhatIf -eq 'true' : $env:PSMODULE_AUTO_RELEASE_INPUT_WhatIf -eq 'true'
 
@@ -64,6 +65,7 @@ LogGroup 'Set configuration' {
     Write-Output "Incremental prerelease enabled: [$incrementalPrerelease]"
     Write-Output "Use PR body as release notes:   [$usePRBodyAsReleaseNotes]"
     Write-Output "Use PR title as release name:   [$usePRTitleAsReleaseName]"
+    Write-Output "Use PR title as notes heading:  [$usePRTitleAsNotesHeading]"
     Write-Output "Version prefix:                 [$versionPrefix]"
     Write-Output "What if mode:                   [$whatIf]"
     Write-Output ''
@@ -243,7 +245,13 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
             }
 
             # Add notes parameter
-            if ($usePRBodyAsReleaseNotes) {
+            if ($usePRTitleAsNotesHeading) {
+                $prTitle = $pull_request.title
+                $prBody = $pull_request.body
+                $notes = "## $prTitle`n`n$prBody"
+                $releaseCreateCommand += @("--notes", "$notes")
+                Write-Output 'Using PR title as H2 heading and body as release notes'
+            } elseif ($usePRBodyAsReleaseNotes) {
                 $prBody = $pull_request.body
                 $releaseCreateCommand += @("--notes", "$prBody")
                 Write-Output 'Using PR body as release notes'
@@ -288,7 +296,13 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
             }
 
             # Add notes parameter
-            if ($usePRBodyAsReleaseNotes) {
+            if ($usePRTitleAsNotesHeading) {
+                $prTitle = $pull_request.title
+                $prBody = $pull_request.body
+                $notes = "## $prTitle`n`n$prBody"
+                $releaseCreateCommand += @("--notes", "$notes")
+                Write-Output 'Using PR title as H2 heading and body as release notes'
+            } elseif ($usePRBodyAsReleaseNotes) {
                 $prBody = $pull_request.body
                 $releaseCreateCommand += @("--notes", "$prBody")
                 Write-Output 'Using PR body as release notes'


### PR DESCRIPTION
## Summary

This update introduces a new configuration option, `UsePRTitleAsNotesHeading`, which uses the pull request (PR) title to be used as a heading in the generated release notes. When enabled, the PR title will appear as a first-level heading (`#`) in the release notes, enhancing readability and organization.

### ✅ Changes

* Added `UsePRTitleAsNotesHeading` configuration option to control the inclusion of PR titles as headings in release notes.
* Updated the release note generation logic to conditionally include PR titles based on the new configuration setting.

### 🛠 Configuration

As this feature is enabled by default, disable it by setting the `UsePRTitleAsNotesHeading` option to `false` on the action.
