### PR TITLE
🩹 [Patch]: Refactor release notes handling to improve clarity and structure

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -233,19 +233,19 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
             }
 
             # Build release creation command with options
-            $releaseCreateCommand = @("release", "create", "$newVersion")
+            $releaseCreateCommand = @('release', 'create', "$newVersion")
 
             # Add title parameter
             if ($usePRTitleAsReleaseName) {
                 $prTitle = $pull_request.title
-                $releaseCreateCommand += @("--title", "$prTitle")
+                $releaseCreateCommand += @('--title', "$prTitle")
                 Write-Output "Using PR title as release name: [$prTitle]"
             } else {
-                $releaseCreateCommand += @("--title", "$newVersion")
+                $releaseCreateCommand += @('--title', "$newVersion")
             }
 
             # Add notes parameter
-            $notes = ""
+            $notes = ''
             if ($usePRTitleAsNotesHeading) {
                 $prTitle = $pull_request.title
                 $prNumber = $pull_request.number
@@ -255,21 +255,17 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
                 $prBody = $pull_request.body
                 $notes += $prBody
             }
-            Write-Output 'gh arguments:'
             if (-not [string]::IsNullOrWhiteSpace($notes)) {
                 $releaseCreateCommand += @('--notes', $notes)
-                Write-Output "$($releaseCreateCommand -join ' ')"
             } else {
                 $releaseCreateCommand += '--generate-notes'
-                Write-Output "$($releaseCreateCommand -join ' ')"
             }
 
             # Add remaining parameters
-            $releaseCreateCommand += @("--target", $prHeadRef, "--prerelease")
+            $releaseCreateCommand += @('--target', $prHeadRef, '--prerelease')
 
-            if ($whatIf) {
-                Write-Output "WhatIf: $releaseCreateCommand"
-            } else {
+            Write-Output "gh $($releaseCreateCommand -join ' ')"
+            if (-not $whatIf) {
                 # Execute the command and capture the output
                 $releaseURL = gh @releaseCreateCommand
                 if ($LASTEXITCODE -ne 0) {
@@ -289,19 +285,19 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
             }
         } else {
             # Build release creation command with options
-            $releaseCreateCommand = @("release", "create", "$newVersion")
+            $releaseCreateCommand = @('release', 'create', "$newVersion")
 
             # Add title parameter
             if ($usePRTitleAsReleaseName) {
                 $prTitle = $pull_request.title
-                $releaseCreateCommand += @("--title", "$prTitle")
+                $releaseCreateCommand += @('--title', "$prTitle")
                 Write-Output "Using PR title as release name: [$prTitle]"
             } else {
-                $releaseCreateCommand += @("--title", "$newVersion")
+                $releaseCreateCommand += @('--title', "$newVersion")
             }
 
             # Add notes parameter
-            $notes = ""
+            $notes = ''
             if ($usePRTitleAsNotesHeading) {
                 $prTitle = $pull_request.title
                 $prNumber = $pull_request.number
@@ -311,19 +307,14 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
                 $prBody = $pull_request.body
                 $notes += $prBody
             }
-            Write-Output "gh arguments:"
             if (-not [string]::IsNullOrWhiteSpace($notes)) {
                 $releaseCreateCommand += @('--notes', $notes)
-                Write-Output "$($releaseCreateCommand -join ' ')"
             } else {
                 $releaseCreateCommand += '--generate-notes'
-                Write-Output "$($releaseCreateCommand -join ' ')"
             }
 
-            if ($whatIf) {
-                Write-Output "WhatIf: $releaseCreateCommand"
-            } else {
-                # Execute the command
+            Write-Output "gh $($releaseCreateCommand -join ' ')"
+            if (-not $whatIf) {
                 gh @releaseCreateCommand
                 if ($LASTEXITCODE -ne 0) {
                     Write-Error "Failed to create the release [$newVersion]."

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -245,19 +245,23 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
             }
 
             # Add notes parameter
+            $notes = ""
             if ($usePRTitleAsNotesHeading) {
                 $prTitle = $pull_request.title
                 $prNumber = $pull_request.number
+                $notes += "# $prTitle (#$prNumber)`n`n"
+            }
+            if ($usePRBodyAsReleaseNotes) {
                 $prBody = $pull_request.body
-                $notes = "# $prTitle (#$prNumber)`n`n$prBody"
-                $releaseCreateCommand += @("--notes", "$notes")
-                Write-Output 'Using PR title as H1 heading with link and body as release notes'
-            } elseif ($usePRBodyAsReleaseNotes) {
-                $prBody = $pull_request.body
-                $releaseCreateCommand += @("--notes", "$prBody")
-                Write-Output 'Using PR body as release notes'
+                $notes += $prBody
+            }
+            Write-Output 'gh arguments:'
+            if (-not [string]::IsNullOrWhiteSpace($notes)) {
+                $releaseCreateCommand += @('--notes', $notes)
+                Write-Output "$($releaseCreateCommand -join ' ')"
             } else {
                 $releaseCreateCommand += '--generate-notes'
+                Write-Output "$($releaseCreateCommand -join ' ')"
             }
 
             # Add remaining parameters
@@ -297,19 +301,23 @@ if ($createPrerelease -or $createRelease -or $whatIf) {
             }
 
             # Add notes parameter
+            $notes = ""
             if ($usePRTitleAsNotesHeading) {
                 $prTitle = $pull_request.title
                 $prNumber = $pull_request.number
+                $notes += "# $prTitle (#$prNumber)`n`n"
+            }
+            if ($usePRBodyAsReleaseNotes) {
                 $prBody = $pull_request.body
-                $notes = "# $prTitle (#$prNumber)`n`n$prBody"
-                $releaseCreateCommand += @("--notes", "$notes")
-                Write-Output 'Using PR title as H1 heading with link and body as release notes'
-            } elseif ($usePRBodyAsReleaseNotes) {
-                $prBody = $pull_request.body
-                $releaseCreateCommand += @("--notes", "$prBody")
-                Write-Output 'Using PR body as release notes'
+                $notes += $prBody
+            }
+            Write-Output "gh arguments:"
+            if (-not [string]::IsNullOrWhiteSpace($notes)) {
+                $releaseCreateCommand += @('--notes', $notes)
+                Write-Output "$($releaseCreateCommand -join ' ')"
             } else {
                 $releaseCreateCommand += '--generate-notes'
+                Write-Output "$($releaseCreateCommand -join ' ')"
             }
 
             if ($whatIf) {


### PR DESCRIPTION
## Description

This pull request refactors the logic for constructing release notes in `scripts/main.ps1` to improve clarity and maintainability. The changes separate the handling of PR title and body into distinct blocks and ensure that notes are only added when they are non-empty.

### Improvements to release notes construction:

* Refactored the logic to initialize `$notes` as an empty string and append the PR title and body conditionally, instead of combining them in a single step. This improves readability and modularity.
* Added a check to ensure that `$notes` is non-empty before appending it to the `$releaseCreateCommand`, preventing unnecessary arguments when no notes are provided.
* Enhanced debugging output by including the constructed `gh` arguments for better traceability during execution.