### PR TITLE
🩹 [Patch]: Add labels to Dependabot updates for better categorization

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,15 @@ version: 2
 updates:
   - package-ecosystem: github-actions # See documentation for possible values
     directory: / # Location of package manifests
+    labels:
+      - dependencies
+      - github-actions
     schedule:
       interval: weekly
   - package-ecosystem: nuget # See documentation for possible values
     directory: / # Location of package manifests
+    labels:
+      - dependencies
+      - nuget
     schedule:
       interval: weekly


### PR DESCRIPTION
## Description

This pull request adds labels to Dependabot configuration for both GitHub Actions and NuGet updates. This will help categorize and filter automated pull requests more easily.

- Dependabot configuration improvements:
  * Added `dependencies` and `github-actions` labels to GitHub Actions updates in `.github/dependabot.yml`.
  * Added `dependencies` and `nuget` labels to NuGet updates in `.github/dependabot.yml`.
